### PR TITLE
Check if $_REQUEST["code"] exists

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -125,7 +125,12 @@ class OpenIDConnectClient
      */
     public function authenticate() {
 
-        $code = $_REQUEST["code"];
+        if (array_key_exists("code", $_REQUEST)) {
+            $code = $_REQUEST["code"];
+        } else {
+            $code = null;
+        }
+
 
         // If we have an authorization code then proceed to request a token
         if ($code) {


### PR DESCRIPTION
A warning is generated if $_REQUEST["code"] does not exist.
