### PR TITLE
Eliminate warning when $this->redirectURL has not been set

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -236,8 +236,9 @@ class OpenIDConnectClient
     public function getRedirectURL() {
         
         // If the redirect URL has been set then return it.
-        if (property_exists($this, ‘redirectURL’) && $this->redirectURL)
+        if (property_exists($this, ‘redirectURL’) && $this->redirectURL) {
             return $this->redirectURL;
+        }
 
         // Other-wise return the URL of the current page
 


### PR DESCRIPTION
Eliminate warning when $this->redirectURL has not previously been set:

PHP Notice:  Undefined property: OpenIDConnectClient::$redirectURL in .../OpenIDConnectClient.php5 on line 239
