### PR TITLE
Add support for signature verification

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -29,6 +29,20 @@ if (!isset($_SESSION)) {
 }
 
 /**
+ *
+ * JWT signature verification support by Jonathan Reed <jdreed@mit.edu>
+ * Licensed under the same license as the rest of this file.
+ *
+ * phpseclib is required to validate the signatures of some tokens.
+ * It can be downloaded from: http://phpseclib.sourceforge.net/
+ */
+
+include('Crypt/RSA.php');
+if (!class_exists('Crypt_RSA')) {
+    user_error('Unable to find phpseclib Crypt/RSA.php.  Ensure phpseclib is installed and in include_path');
+}
+
+/**
  * A wrapper around base64_decode which decodes Base64URL-encoded data,
  * which is not the same alphabet as base64.
  */
@@ -177,6 +191,15 @@ class OpenIDConnectClient
             }
 
             $claims = $this->decodeJWT($token_json->id_token, 1);
+
+	    // Verify the signature
+	    if ($this->canVerifySignatures()) {
+		if (!$this->verifyJWTsignature($token_json->id_token)) {
+		    throw new OpenIDConnectClientException ("Unable to verify signature");
+		}
+	    } else {
+		user_error("Warning: JWT signature verification unavailable.");
+	    }
 
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims)) {
@@ -356,6 +379,79 @@ class OpenIDConnectClient
 
         return json_decode($this->fetchURL($token_endpoint, $token_params));
 
+    }
+
+    /**
+     * @param array $keys
+     * @param string $alg
+     * @throws OpenIDConnectClientException
+     * @return object
+     */
+    private function get_key_for_alg($keys, $alg) {
+        foreach ($keys as $key) {
+            if ($key->kty == $alg) {
+                return $key;
+            }
+        }
+        throw new OpenIDConnectClientException('Unable to find a key for algorithm:' . $alg);
+    }
+
+
+    /**
+     * @param string $hashtype
+     * @param object $key
+     * @throws OpenIDConnectClientException
+     * @return bool
+     */
+    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature) {
+        if (!class_exists('Crypt_RSA')) {
+            throw new OpenIDConnectClientException('Crypt_RSA support unavailable.');
+        }
+        if (!(property_exists($key, 'n') and property_exists($key, 'e'))) {
+            throw new OpenIDConnectClientException('Malformed key object');
+        }
+        /* We already have base64url-encoded data, so re-encode it as
+           regular base64 and use the XML key format for simplicity.
+        */
+        $public_key_xml = "<RSAKeyValue>\r\n".
+            "  <Modulus>" . b64url2b64($key->n) . "</Modulus>\r\n" .
+            "  <Exponent>" . b64url2b64($key->e) . "</Exponent>\r\n" .
+            "</RSAKeyValue>";
+        $rsa = new Crypt_RSA();
+        $rsa->setHash($hashtype);
+        $rsa->loadKey($public_key_xml, CRYPT_RSA_PUBLIC_FORMAT_XML);
+        $rsa->signatureMode = CRYPT_RSA_SIGNATURE_PKCS1;
+        return $rsa->verify($payload, $signature);
+    }
+
+    /**
+     * @param $jwt string encoded JWT
+     * @throws OpenIDConnectClientException
+     * @return bool
+     */
+    private function verifyJWTsignature($jwt) {
+        $parts = explode(".", $jwt);
+        $signature = base64url_decode(array_pop($parts));
+        $header = json_decode(base64url_decode($parts[0]));
+        $payload = implode(".", $parts);
+        $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
+        if ($jwks === NULL) {
+            throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
+        }
+        $verified = false;
+        switch ($header->alg) {
+        case 'RS256':
+        case 'RS384':
+        case 'RS512':
+            $hashtype = 'sha' . substr($header->alg, 2);
+            $verified = $this->verifyRSAJWTsignature($hashtype,
+                                                     $this->get_key_for_alg($jwks->keys, 'RSA'),
+                                                     $payload, $signature);
+            break;
+        default:
+            throw new OpenIDConnectClientException('No support for signature type: ' . $header->alg);
+        }
+        return $verified;
     }
 
     /**
@@ -632,6 +728,13 @@ class OpenIDConnectClient
      */
     public function getClientSecret() {
         return $this->clientSecret;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canVerifySignatures() {
+      return class_exists('Crypt_RSA');
     }
 
 


### PR DESCRIPTION
In working on expanding our documentation for our OIDC deployment at MIT, I noticed that none of the PHP libraries out there seem to verify signatures.  This adds preliminary support for verifying signatures (RSA only), using [phpseclib](http://phpseclib.sourceforge.net/).

It also ensures that the base64urlencoded data is decoded correctly, by implementing base64 url decoding as described in RFC4648 section 5, "Base 64 Encoding with URL and Filename Safe Alphabet"
