### PR TITLE
Handle the case of user denying openid scope; fix PHP strict mode errors

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -190,6 +190,10 @@ class OpenIDConnectClient
                 throw new OpenIDConnectClientException("Unable to determine state");
             }
 
+	    if (!property_exists($token_json, 'id_token')) {
+		throw new OpenIDConnectClientException("User did not authorize openid scope.");
+	    }
+
             $claims = $this->decodeJWT($token_json->id_token, 1);
 
 	    // Verify the signature


### PR DESCRIPTION
51def84 fixes a warning in PHP strict mode about calling reset() with the return value of a function (instead of an array).

c51a8c3 handles the case of the user clicking 'Authorize' at the OIDC server, but denying the openid scope.
