### PR TITLE
Use syntax suitable for PHP 5.2

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -305,7 +305,8 @@ class OpenIDConnectClient
             $base_page_url .= $_SERVER["SERVER_NAME"];
         }
 
-        $base_page_url .= explode("?", $_SERVER['REQUEST_URI'])[0];
+        $tmp = explode("?", $_SERVER['REQUEST_URI']);
+        $base_page_url .= $tmp[0];
 
         return $base_page_url;
     }


### PR DESCRIPTION
51def840 introduced syntax that was incompatible with PHP 5.3 and
earlier.  Revert to using a temporary variable.