### PR TITLE
Update key selection to use both alg & kid

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -388,6 +388,21 @@ class OpenIDConnectClient
 
     /**
      * @param array $keys
+     * @param array $header
+     * @throws OpenIDConnectClientException
+     * @return object
+     */
+    private function get_key_for_header($keys, $header) {
+        foreach ($keys as $key) {
+            if ($key->alg == $header->alg && $key->kid == $header->kid) {
+                return $key;
+            }
+        }
+        throw new OpenIDConnectClientException('Unable to find a key for (algorithm, kid):' . $header->alg . ', ' . $header->kid . ')');
+    }
+
+    /**
+     * @param array $keys
      * @param string $alg
      * @throws OpenIDConnectClientException
      * @return object
@@ -450,7 +465,7 @@ class OpenIDConnectClient
         case 'RS512':
             $hashtype = 'sha' . substr($header->alg, 2);
             $verified = $this->verifyRSAJWTsignature($hashtype,
-                                                     $this->get_key_for_alg($jwks->keys, 'RSA'),
+                                                     $this->get_key_for_header($jwks->keys, $header),
                                                      $payload, $signature);
             break;
         default:


### PR DESCRIPTION
## Summary

I believe this will take care of at least part of https://github.com/jumbojett/OpenID-Connect-PHP/issues/18, specifically the seemingly random failures to validate a key.

I manually followed the `jwks_url` (<https://www.googleapis.com/oauth2/v2/certs>) and noticed that there were two signatures for the same `alg` (see below **jwks_url**).

So, I decided to use both the `alg` and `kid` fields in the first part of the JWT (see below **JWT Part 1**) to select instead of just one.

## Notes

1. This has only been tested against Google's implementation
2. It's not in this PR, but I also removed the `nonce` check
3. I left things like `$hashtype` and `get_key_for_alg()` in place, even though they're no longer used

---

## Appendix

### JWT Part 1
```
{
  "alg": "RS256",
  "kid": "75b10ce676e9ed4d1089b70b9557c06e8c0b8028"
}
```

### jwks_url
```
{
 "keys": [
  {
   "kty": "RSA",
   "alg": "RS256",
   "use": "sig",
   "kid": "3ccd4df6f09dcfe7fba19700941fc5b2e385fa43",
   "n": "xrBGpxxaQP_VYHjN5NaMCY8Fn7-UrM7KoUAnL3lk7-A9pD4JHophKsOQtZ0IBE3K8CDZIEGuPF1dx9xeUSNwHbf_7Ntgxm5SN3KF9ZX6j11SojY1el48595fTlxOuGtTwwSQlwsF4qIPztTI_T9qJvgeJUmbdvq5grxQ5kFUxjk=",
   "e": "AQAB"
  },
  {
   "kty": "RSA",
   "alg": "RS256",
   "use": "sig",
   "kid": "75b10ce676e9ed4d1089b70b9557c06e8c0b8028",
   "n": "vXxsJ4nCB-8SAy44zHOmmBuCMdfnq2BJqKQXuTKfHehOwmfdthpffErF5lGB4uEtiuXuixFu3dh4AMb8VTGO9s24uD0W5w9MCCG0JrdGrfgdyj3z_1cUYIps_ROJv3qoy2Z-jX8evEru26X4tAZRh3-9abg3SBpGCUk3R8RsWsk=",
   "e": "AQAB"
  }
 ]
}
```