### PR TITLE
Trim providerURL slash for verifyJWTclaims

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -482,7 +482,7 @@ class OpenIDConnectClient
      */
     private function verifyJWTclaims($claims) {
 
-        return (($claims->iss == $this->getProviderURL())
+        return (($claims->iss == rtrim($this->getProviderURL(),"/"))
             && (($claims->aud == $this->clientID) || (in_array($this->clientID, $claims->aud)))
             && ($claims->nonce == $_SESSION['openid_connect_nonce']));
 

--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -482,7 +482,7 @@ class OpenIDConnectClient
      */
     private function verifyJWTclaims($claims) {
 
-        return (($claims->iss == rtrim($this->getProviderURL(),"/"))
+        return ((rtrim($claims->iss,"/") == rtrim($this->getProviderURL(),"/"))
             && (($claims->aud == $this->clientID) || (in_array($this->clientID, $claims->aud)))
             && ($claims->nonce == $_SESSION['openid_connect_nonce']));
 


### PR DESCRIPTION
A trailing slash can cause JWT verification to fail unnecessarily.