### PR TITLE
Update OpenIDConnectClient.php5

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -474,8 +474,12 @@ class OpenIDConnectClient
         case 'RS384':
         case 'RS512':
             $hashtype = 'sha' . substr($header->alg, 2);
-            $verified = $this->verifyRSAJWTsignature($hashtype,
-                                                     $this->get_key_for_header($jwks->keys, $header),
+            if (isset($header->kid)) {
+                $key = $this->get_key_for_header($jwks->keys, $header);
+            } else {
+                $key = $this->get_key_for_alg($jwks->keys, 'RSA');
+            }        
+            $verified = $this->verifyRSAJWTsignature($hashtype, $key,
                                                      $payload, $signature);
             break;
         default:


### PR DESCRIPTION
Patch https://github.com/jumbojett/OpenID-Connect-PHP/commit/19a23a84110095188c0d45492e56bd2d4bdebb43 introduced a problem for our environment where $header->kid is undefined. The code dies on line 406 and is unable to even throw the exception on line 410 because of the missing field. I'm not sure if the proposed fix is the best solution, but it does may the code work again.