### PR TITLE
Fix duplicate curl call

### DIFF
--- a/OpenIDConnectClient.php5
+++ b/OpenIDConnectClient.php5
@@ -627,7 +627,7 @@ class OpenIDConnectClient
         // Download the given URL, and return output
         $output = curl_exec($ch);
 
-        if (curl_exec($ch) === false) {
+        if ($output === false) {
             throw new OpenIDConnectClientException('Curl error: ' . curl_error($ch));
         }
 


### PR DESCRIPTION
It was executing curl command 2 times for each request. Now it removes the 2nd call and using the first response to check status.