### PR TITLE
Update code to use current version of phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Bare-bones OpenID Connect client",
     "require": {
         "php": ">=5.2",
-        "phpseclib/phpseclib" : "~0.3.10",
+        "phpseclib/phpseclib" : "2.0.1",
         "ext-json": "*",
         "ext-curl": "*"
     },


### PR DESCRIPTION
The phpseclib this depends on is a bit outdated and conflicts with pear libraries.  This change updates openid-connect-php to use a newer version of phpseclib which is less problematic.