### PR TITLE
Some fixes and improvements (Basic auth, error_description and new methods)

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -418,8 +418,8 @@ class OpenIDConnectClient
         }
 
         // If the client has been registered with additional response types
-        if (sizeof($this->setResponseTypes) > 0) {
-            $auth_params = array_merge($auth_params, array('response_type' => implode(' ', $this->setResponseTypes)));
+        if (sizeof($this->responseTypes) > 0) {
+            $auth_params = array_merge($auth_params, array('response_type' => implode(' ', $this->responseTypes)));
         }
         
         $auth_endpoint .= '?' . http_build_query($auth_params, null, '&');

--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -878,4 +878,18 @@ class OpenIDConnectClient
     public function getIdToken() {
         return $this->idToken;
     }
+
+    /**
+     * @return array
+     */
+    public function getAccessTokenHeader() {
+        return $this->decodeJWT($this->accessToken, 0);
+    }
+
+    /**
+     * @return array
+     */
+    public function getAccessTokenPayload() {
+        return $this->decodeJWT($this->accessToken, 1);
+    }
 }

--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -203,7 +203,10 @@ class OpenIDConnectClient
 
             // Throw an error if the server returns one
             if (isset($token_json->error)) {
-                throw new OpenIDConnectClientException($token_json->error_description);
+                if (isset($token_json->error_description)) {
+                    throw new OpenIDConnectClientException($token_json->error_description);
+                }
+                throw new OpenIDConnectClientException('Got response: ' . $token_json->error);
             }
 
             // Do an OpenID Connect session check

--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -439,9 +439,10 @@ class OpenIDConnectClient
      * @return mixed
      */
     private function requestTokens($code) {
-
-
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
+        $token_endpoint_auth_methods_supported = $this->getProviderConfigValue("token_endpoint_auth_methods_supported");
+
+        $headers = [];
 
         $grant_type = "authorization_code";
 
@@ -453,10 +454,16 @@ class OpenIDConnectClient
             'client_secret' => $this->clientSecret
         );
 
+        # Consider Basic authentication if provider config is set this way
+        if (in_array('client_secret_basic', $token_endpoint_auth_methods_supported)) {
+            $headers = ['Authorization: Basic ' . base64_encode($this->clientID . ':' . $this->clientSecret)];
+            unset($token_params['client_secret']);
+        }
+
         // Convert token params to string format
         $token_params = http_build_query($token_params, null, '&');
 
-        return json_decode($this->fetchURL($token_endpoint, $token_params));
+        return json_decode($this->fetchURL($token_endpoint, $token_params, $headers));
 
     }
 


### PR DESCRIPTION
Hi guys!

I just made some changes while playing with coreos/dex as OpenID Connect provider.

- Replaced `$this->setResponseTypes` with `$this->responseTypes` am I wrong ?
- The 'error_description' field is optional. Return the error code if not defined. ([specs](https://openid.net/specs/openid-connect-core-1_0.html#AuthError))
- Basic auth should be used by default (Temp fix so that it works if no other option is available ; as this is the case with coreos/dex) ([specs](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication))
- Some new methods for convenience with decoding JWT. (Maybe it's not necessary ?)
