### PR TITLE
Fix a key verification issue with Azure AD

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -502,8 +502,14 @@ class OpenIDConnectClient
       */
      private function get_key_for_header($keys, $header) {
          foreach ($keys as $key) {
-           if ((!(isset($key->alg) && isset($header->kid)) && $key->kty == 'RSA') || ($key->alg == $header->alg && $key->kid == $header->kid)) {
-                 return $key;
+             if ($key->kty == 'RSA') {
+                 if (!isset($header->kid) || $key->kid == $header->kid) {
+                     return $key;
+                 }
+             } else {
+                 if ($key->alg == $header->alg && $key->kid == $header->kid) {
+                     return $key;
+                 }
              }
          }
          if (isset($header->kid)) {


### PR DESCRIPTION
This fixes an issue where the wrong key is selected to verify the JWT signature when multiple RSA keys are available.

Azure AD currently provides multiple RSA keys (see [here](https://login.microsoftonline.com/common/discovery/keys)) that signatures can be verified against. Since `alg` is not specified for these keys, the previous logic in this function returned the first RSA key it found even though the `kid` value did not match.

This change modifies the function to verify `kid` values for RSA keys if a `kid` value is present in the token header. I also cleaned it up a bit and separated the logic into multiple `if` statements to help improve readability.