### PR TITLE
Expose configuration of verify peer/host

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -121,6 +121,16 @@ class OpenIDConnectClient
      * @var string full system path to the SSL certificate
      */
     private $certPath;
+    
+    /**
+     * @var bool Verify SSL peer on transactions
+     */
+    private $verifyPeer = true;
+    
+    /**
+     * @var bool Verify peer hostname on transactions
+     */
+    private $verifyHost = true;
 
     /**
      * @var string if we aquire an access token it will be stored here
@@ -787,13 +797,21 @@ class OpenIDConnectClient
          * Otherwise ignore SSL peer verification
          */
         if (isset($this->certPath)) {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_CAINFO, $this->certPath);
-        } else {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
         }
-
+        
+        if($this->verifyHost) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        }
+        
+        if($this->verifyPeer) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);        
+        }
+        
         // Should cURL return or print out the data? (true = return, false = print)
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
@@ -846,6 +864,20 @@ class OpenIDConnectClient
      */
     public function setCertPath($certPath) {
         $this->certPath = $certPath;
+    }
+    
+    /**
+     * @param bool $verifyPeer
+     */
+    public function setVerifyPeer($verifyPeer) {
+        $this->verifyPeer = $verifyPeer;
+    }
+    
+    /**
+     * @param bool $verifyHost
+     */
+    public function setVerifyHost($verifyHost) {
+        $this->verifyHost = $verifyHost;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ require '/vendor/autoload.php';
 $oidc = new OpenIDConnectClient('https://id.provider.com/',
                                 'ClientIDHere',
                                 'ClientSecretHere');
-
+$oidc->setCertPath('/path/to/my.cert');
 $oidc->authenticate();
 $name = $oidc->requestUserInfo('given_name');
 
@@ -68,6 +68,15 @@ $oidc->addScope('my_scope');
 // this assumes success (to validate check if the access_token property is there and a valid JWT) :
 $clientCredentialsToken = $oidc->requestClientCredentialsToken()->access_token;
 
+```
+
+## Development Environments ##
+In some cases you may need to disable SSL security on on your development systems.
+Note: This is not recommended on production systems.
+
+```php
+$oidc->setVerifyHost(false);
+$oidc->setVerifyPeer(false);
 ```
 
 ### Todo ###


### PR DESCRIPTION
This pull request is to help with two issues I had with this library.

1. Exposes the ability to turn off peer hostname resolution. This may be common for development machines running on wildcard domains.

2. Changes the default state of the connection to have SSL peer/host verification enabled by default. This will require users to define their path to their CA certificate. This is likely better than systems going live with the potential of middle-man exploits.