### PR TITLE
Not depending on composer build to run phpseclib

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -37,8 +37,8 @@ if (!isset($_SESSION)) {
  * It can be downloaded from: http://phpseclib.sourceforge.net/
  */
 
-if (!class_exists('\phpseclib\Crypt\RSA')) {
-    user_error('Unable to find phpseclib Crypt/RSA.php.  Ensure phpseclib is installed and in include_path');
+if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
+    user_error('Unable to find phpseclib Crypt/RSA.php.  Ensure phpseclib is installed and in include_path before you include this file');
 }
 
 /**
@@ -592,7 +592,7 @@ class OpenIDConnectClient
      * @return bool
      */
     private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature) {
-        if (!class_exists('\phpseclib\Crypt\RSA')) {
+        if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
             throw new OpenIDConnectClientException('Crypt_RSA support unavailable.');
         }
         if (!(property_exists($key, 'n') and property_exists($key, 'e'))) {
@@ -606,10 +606,17 @@ class OpenIDConnectClient
             "  <Modulus>" . b64url2b64($key->n) . "</Modulus>\r\n" .
             "  <Exponent>" . b64url2b64($key->e) . "</Exponent>\r\n" .
             "</RSAKeyValue>";
-        $rsa = new \phpseclib\Crypt\RSA();
-        $rsa->setHash($hashtype);
-        $rsa->loadKey($public_key_xml, \phpseclib\Crypt\RSA::PUBLIC_FORMAT_XML);
-        $rsa->signatureMode = \phpseclib\Crypt\RSA::SIGNATURE_PKCS1;
+	if(class_exists('Crypt_RSA')) {
+        	$rsa = new Crypt_RSA();
+		$rsa->setHash($hashtype);
+        	$rsa->loadKey($public_key_xml, Crypt_RSA::PUBLIC_FORMAT_XML);
+        	$rsa->signatureMode = Crypt_RSA::SIGNATURE_PKCS1;
+	} else {
+		$rsa = new \phpseclib\Crypt\RSA();
+		$rsa->setHash($hashtype);
+        	$rsa->loadKey($public_key_xml, \phpseclib\Crypt\RSA::PUBLIC_FORMAT_XML);
+        	$rsa->signatureMode = \phpseclib\Crypt\RSA::SIGNATURE_PKCS1;
+	}
         return $rsa->verify($payload, $signature);
     }
 
@@ -976,7 +983,7 @@ class OpenIDConnectClient
      * @return bool
      */
     public function canVerifySignatures() {
-      return class_exists('\phpseclib\Crypt\RSA');
+      return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
     /**


### PR DESCRIPTION
If you choose to simply include the file instead of build from composer, the class declarations were wonky and failed despite including phpseclib prior to this file.