### PR TITLE
Add check for jwks_uri prior to calling verifyJWTsignature()

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -246,6 +246,9 @@ class OpenIDConnectClient
 
             // Verify the signature
             if ($this->canVerifySignatures()) {
+		if (!$this->getProviderConfigValue('jwks_uri')) {
+                    throw new OpenIDConnectClientException ("Unable to verify signature due to no jwks_uri being defined");
+                }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
                     throw new OpenIDConnectClientException ("Unable to verify signature");
                 }


### PR DESCRIPTION
You need the jwks_uri prior to calling the verifyJWTsignature() I had it throw an exception for the end user so they know that param is required even if the provider doesn't tell them so in the json response.