### PR TITLE
fix: remove response_mode

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -449,7 +449,6 @@ class OpenIDConnectClient
 
         $auth_params = array_merge($this->authParams, array(
             'response_type' => $response_type,
-            'response_mode' => "form_post",
             'redirect_uri' => $this->getRedirectURL(),
             'client_id' => $this->clientID,
             'nonce' => $nonce,


### PR DESCRIPTION
Anvil Connect only supports the following response modes:
'query', 'fragment'.

See
https://github.com/anvilresearch/connect/blob/747b625395e7232ec1c43a6fcdac241e2af6dc24/oidc/validateAuthorizationParams.js#L23