### PR TITLE
Update OpenIDConnectClient.php

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -409,10 +409,14 @@ class OpenIDConnectClient
          * Support of 'ProxyReverse' configurations.
          */
 
-        $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO'] 
-                  ?: @$_SERVER['REQUEST_SCHEME']
-                  ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
-
+        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) {
+            $protocol = 'https';
+        } else {
+            $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO'] 
+                ?: @$_SERVER['REQUEST_SCHEME']
+                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
+        }
+	    
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
               ?: @intval($_SERVER["SERVER_PORT"])
               ?: (($protocol === 'https') ? 443 : 80);


### PR DESCRIPTION
When this code is running on a server not running SSL natively,  but being proxy-ed behind a F5 doing SSL termination, it sets the header "HTTP_UPGRADE_INSECURE_REQUESTS", but only exposes 80. There is no way to know it came from a SSL terminated session.

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
