### PR TITLE
Broken when behind a proxy doing SSL termination

### DIFF
--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -409,9 +409,13 @@ class OpenIDConnectClient
          * Support of 'ProxyReverse' configurations.
          */
 
-        $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO'] 
-                  ?: @$_SERVER['REQUEST_SCHEME']
-                  ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
+        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) {
+            $protocol = 'https';
+        } else {
+            $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO'] 
+                ?: @$_SERVER['REQUEST_SCHEME']
+                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
+        }
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
               ?: @intval($_SERVER["SERVER_PORT"])

--- a/OpenIDConnectClient.php
+++ b/OpenIDConnectClient.php
@@ -409,13 +409,13 @@ class OpenIDConnectClient
          * Support of 'ProxyReverse' configurations.
          */
 
-        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) {
-            $protocol = 'https';
-        } else {
-            $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO'] 
-                ?: @$_SERVER['REQUEST_SCHEME']
-                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
-        }
+        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) { 
+            $protocol = 'https'; 
+        } else { 
+            $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
+                ?: @$_SERVER['REQUEST_SCHEME'] 
+                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http"); 
+        } 
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
               ?: @intval($_SERVER["SERVER_PORT"])


### PR DESCRIPTION
Add check for header "HTTP_UPGRADE_INSECURE_REQUESTS". Needed when this code is behind a proxy doing SSL termination.  Tested on F5 BigIP 12.1.2.  F5 adds the header, which this uses to rewrite the request added "https" to the original "http". 
