### PR TITLE
Travis PSR-2 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - '5.4'
+  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
-install: composer install --dev
+install: composer install
 script: ./vendor/phing/phing/bin/phing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+  - '5.4'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+install: composer install --dev
+script: ./vendor/phing/phing/bin/phing

--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ $oidc->setVerifyPeer(false);
   
 ## Contributing ###
  - All pull requests, once merged, should be added to the changelog.md file.
+ - OpenID-Connect's source code is formatted according to the PSR-2 standard.
+

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="jumbojett/openid-connect-php" default="phpcs">
+    <php expression="include('vendor/autoload.php')"/>
+    <target name="phpcs">
+        <phpcodesniffer standard="PSR2" description="Run PSR2 standards over the codebase" haltonerror="true">
+            <fileset dir="src">
+                <include name="**/*.php"/>
+            </fileset>
+           <formatter type="full" usefile="false"/>
+        </phpcodesniffer>
+    </target>
+</project>

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         "ext-json": "*",
         "ext-curl": "*"
     },
+    "require-dev": {
+        "phing/phing": "^2.16",
+        "squizlabs/php_codesniffer": "^2.0"
+    },
     "autoload": {
         "classmap": ["OpenIDConnectClient.php"]
     }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -260,7 +260,7 @@ class OpenIDConnectClient
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
                     throw new OpenIDConnectClientException(
-                    "Unable to verify signature due to no jwks_uri being defined"
+                        "Unable to verify signature due to no jwks_uri being defined"
                     );
                 }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
@@ -552,7 +552,6 @@ class OpenIDConnectClient
         $token_params = http_build_query($token_params, null, '&');
 
         return json_decode($this->fetchURL($token_endpoint, $token_params, $headers));
-
     }
 
     /**
@@ -589,8 +588,8 @@ class OpenIDConnectClient
       * @throws OpenIDConnectClientException
       * @return object
       */
-     private function getKeyForHeader($keys, $header)
-     {
+    private function getKeyForHeader($keys, $header)
+    {
         foreach ($keys as $key) {
             if ($key->kty == 'RSA') {
                 if (!isset($header->kid) || $key->kid == $header->kid) {

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -447,7 +447,7 @@ class OpenIDConnectClient
      */
     protected function generateRandString()
     {
-        return md5(uniqid(rand(), TRUE));
+        return md5(uniqid(rand(), true));
     }
 
     /**
@@ -659,7 +659,7 @@ class OpenIDConnectClient
         $header = json_decode(base64url_decode($parts[0]));
         $payload = implode(".", $parts);
         $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
-        if ($jwks === NULL) {
+        if ($jwks === null) {
             throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
         }
         $verified = false;

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -47,7 +47,8 @@ if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
  * A wrapper around base64_decode which decodes Base64URL-encoded data,
  * which is not the same alphabet as base64.
  */
-function base64url_decode($base64url) {
+function base64url_decode($base64url)
+{
     return base64_decode(b64url2b64($base64url));
 }
 
@@ -58,7 +59,8 @@ function base64url_decode($base64url) {
  * but we'll do it anyway.
  *
  */
-function b64url2b64($base64url) {
+function b64url2b64($base64url)
+{
     // "Shouldn't" be necessary, but why not
     $padding = strlen($base64url) % 4;
     if ($padding > 0) {
@@ -191,7 +193,8 @@ class OpenIDConnectClient
      * @param $client_secret string optional
      *
      */
-    public function __construct($provider_url = null, $client_id = null, $client_secret = null) {
+    public function __construct($provider_url = null, $client_id = null, $client_secret = null)
+    {
         $this->setProviderURL($provider_url);
         $this->clientID = $client_id;
         $this->clientSecret = $client_secret;
@@ -200,14 +203,16 @@ class OpenIDConnectClient
     /**
      * @param $provider_url
      */
-    public function setProviderURL($provider_url) {
+    public function setProviderURL($provider_url)
+    {
         $this->providerConfig['issuer'] = $provider_url;
     }
 
     /**
      * @param $response_types
      */
-    public function setResponseTypes($response_types) {
+    public function setResponseTypes($response_types)
+    {
         $this->responseTypes = array_merge($this->responseTypes, (array)$response_types);
     }
 
@@ -215,7 +220,8 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    public function authenticate() {
+    public function authenticate()
+    {
 
         // Do a preemptive check to see if the provider has thrown an error from a previous redirect
         if (isset($_REQUEST['error'])) {
@@ -307,7 +313,8 @@ class OpenIDConnectClient
      * registered with the OP. Value can be null.
      *
      */
-    public function signOut($accessToken, $redirect) {
+    public function signOut($accessToken, $redirect)
+    {
         $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
@@ -327,14 +334,16 @@ class OpenIDConnectClient
     /**
      * @param $scope - example: openid, given_name, etc...
      */
-    public function addScope($scope) {
+    public function addScope($scope)
+    {
         $this->scopes = array_merge($this->scopes, (array)$scope);
     }
 
     /**
      * @param $param - example: prompt=login
      */
-    public function addAuthParam($param) {
+    public function addAuthParam($param)
+    {
         $this->authParams = array_merge($this->authParams, (array)$param);
     }
 
@@ -347,7 +356,8 @@ class OpenIDConnectClient
      * @return string
      *
      */
-    private function getProviderConfigValue($param, $default = null) {
+    private function getProviderConfigValue($param, $default = null)
+    {
 
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
@@ -380,7 +390,8 @@ class OpenIDConnectClient
     /**
      * @param $url Sets redirect URL for auth flow
      */
-    public function setRedirectURL ($url) {
+    public function setRedirectURL ($url)
+    {
         if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
             $this->redirectURL = $url;
         }
@@ -391,7 +402,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    public function getRedirectURL() {
+    public function getRedirectURL()
+    {
 
         // If the redirect URL has been set then return it.
         if (property_exists($this, 'redirectURL') && $this->redirectURL) {
@@ -437,7 +449,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function generateRandString() {
+    protected function generateRandString()
+    {
         return md5(uniqid(rand(), TRUE));
     }
 
@@ -445,7 +458,8 @@ class OpenIDConnectClient
      * Start Here
      * @return void
      */
-    private function requestAuthorization() {
+    private function requestAuthorization()
+    {
 
         $auth_endpoint = $this->getProviderConfigValue("authorization_endpoint");
         $response_type = "code";
@@ -486,7 +500,8 @@ class OpenIDConnectClient
      * Requests a client credentials token
      *
      */
-    public function requestClientCredentialsToken() {
+    public function requestClientCredentialsToken()
+    {
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
         $token_endpoint_auth_methods_supported = $this->getProviderConfigValue("token_endpoint_auth_methods_supported");
 
@@ -514,7 +529,8 @@ class OpenIDConnectClient
      * @param $code
      * @return mixed
      */
-    private function requestTokens($code) {
+    private function requestTokens($code)
+    {
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
         $token_endpoint_auth_methods_supported = $this->getProviderConfigValue("token_endpoint_auth_methods_supported", ['client_secret_basic']);
 
@@ -549,7 +565,8 @@ class OpenIDConnectClient
      * @param $code
      * @return mixed
      */
-    public function refreshToken($refresh_token) {
+    public function refreshToken($refresh_token)
+    {
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
 
         $grant_type = "refresh_token";
@@ -576,7 +593,8 @@ class OpenIDConnectClient
       * @throws OpenIDConnectClientException
       * @return object
       */
-     private function get_key_for_header($keys, $header) {
+     private function get_key_for_header($keys, $header)
+     {
          foreach ($keys as $key) {
              if ($key->kty == 'RSA') {
                  if (!isset($header->kid) || $key->kid == $header->kid) {
@@ -603,7 +621,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return bool
      */
-    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature) {
+    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature)
+    {
         if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
             throw new OpenIDConnectClientException('Crypt_RSA support unavailable.');
         }
@@ -637,7 +656,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return bool
      */
-    private function verifyJWTsignature($jwt) {
+    private function verifyJWTsignature($jwt)
+    {
         $parts = explode(".", $jwt);
         $signature = base64url_decode(array_pop($parts));
         $header = json_decode(base64url_decode($parts[0]));
@@ -667,8 +687,9 @@ class OpenIDConnectClient
      * @param object $claims
      * @return bool
      */
-    private function verifyJWTclaims($claims, $accessToken = null) {
-	if(isset($claims->at_hash) && isset($accessToken)){
+    private function verifyJWTclaims($claims, $accessToken = null)
+    {
+        if(isset($claims->at_hash) && isset($accessToken)){
             if(isset($this->getAccessTokenHeader()->alg) && $this->getAccessTokenHeader()->alg != 'none'){
                 $bit = substr($this->getAccessTokenHeader()->alg, 2, 3);
             }else{
@@ -691,7 +712,8 @@ class OpenIDConnectClient
      * @param string $str
      * @return string
      */
-    protected function urlEncode($str) {
+    protected function urlEncode($str)
+    {
         $enc = base64_encode($str);
         $enc = rtrim($enc, "=");
         $enc = strtr($enc, "+/", "-_");
@@ -703,7 +725,8 @@ class OpenIDConnectClient
      * @param int $section the section we would like to decode
      * @return object
      */
-    private function decodeJWT($jwt, $section = 0) {
+    private function decodeJWT($jwt, $section = 0)
+    {
 
         $parts = explode(".", $jwt);
         return json_decode(base64url_decode($parts[$section]));
@@ -736,8 +759,8 @@ class OpenIDConnectClient
      * @return mixed
      *
      */
-    public function requestUserInfo($attribute = null) {
-
+    public function requestUserInfo($attribute = null)
+    {
         $user_info_endpoint = $this->getProviderConfigValue("userinfo_endpoint");
         $schema = 'openid';
 
@@ -766,9 +789,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return mixed
      */
-    protected function fetchURL($url, $post_body = null,$headers = array()) {
-
-
+    protected function fetchURL($url, $post_body = null,$headers = array())
+    {
         // OK cool - then let's create a new cURL resource handle
         $ch = curl_init();
 
@@ -858,7 +880,8 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getProviderURL() {
+    public function getProviderURL()
+    {
 
         if (!isset($this->providerConfig['issuer'])) {
             throw new OpenIDConnectClientException("The provider URL has not been set");
@@ -870,7 +893,8 @@ class OpenIDConnectClient
     /**
      * @param $url
      */
-    public function redirect($url) {
+    public function redirect($url)
+    {
         header('Location: ' . $url);
         exit;
     }
@@ -878,14 +902,16 @@ class OpenIDConnectClient
     /**
      * @param $httpProxy
      */
-    public function setHttpProxy($httpProxy) {
+    public function setHttpProxy($httpProxy)
+    {
         $this->httpProxy = $httpProxy;
     }
 
     /**
      * @param $certPath
      */
-    public function setCertPath($certPath) {
+    public function setCertPath($certPath)
+    {
         $this->certPath = $certPath;
     }
 
@@ -900,14 +926,16 @@ class OpenIDConnectClient
     /**
      * @param bool $verifyPeer
      */
-    public function setVerifyPeer($verifyPeer) {
+    public function setVerifyPeer($verifyPeer)
+    {
         $this->verifyPeer = $verifyPeer;
     }
     
     /**
      * @param bool $verifyHost
      */
-    public function setVerifyHost($verifyHost) {
+    public function setVerifyHost($verifyHost)
+    {
         $this->verifyHost = $verifyHost;
     }
 
@@ -934,21 +962,24 @@ class OpenIDConnectClient
      * @param $array
      *        simple key => value
      */
-    public function providerConfigParam($array) {
+    public function providerConfigParam($array)
+    {
         $this->providerConfig = array_merge($this->providerConfig, $array);
     }
 
     /**
      * @param $clientSecret
      */
-    public function setClientSecret($clientSecret) {
+    public function setClientSecret($clientSecret)
+    {
         $this->clientSecret = $clientSecret;
     }
 
     /**
      * @param $clientID
      */
-    public function setClientID($clientID) {
+    public function setClientID($clientID)
+    {
         $this->clientID = $clientID;
     }
 
@@ -958,7 +989,8 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function register() {
+    public function register()
+    {
 
         $registration_endpoint = $this->getProviderConfigValue('registration_endpoint');
 
@@ -994,35 +1026,40 @@ class OpenIDConnectClient
     /**
      * @return mixed
      */
-    public function getClientName() {
+    public function getClientName()
+    {
         return $this->clientName;
     }
 
     /**
      * @param $clientName
      */
-    public function setClientName($clientName) {
+    public function setClientName($clientName)
+    {
         $this->clientName = $clientName;
     }
 
     /**
      * @return string
      */
-    public function getClientID() {
+    public function getClientID()
+    {
         return $this->clientID;
     }
 
     /**
      * @return string
      */
-    public function getClientSecret() {
+    public function getClientSecret()
+    {
         return $this->clientSecret;
     }
 
     /**
      * @return bool
      */
-    public function canVerifySignatures() {
+    public function canVerifySignatures()
+    {
       return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
@@ -1035,62 +1072,71 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    public function setAccessToken($accessToken) {
+    public function setAccessToken($accessToken)
+    {
         $this->accessToken = $accessToken;
     }
 
     /**
      * @return string
      */
-    public function getAccessToken() {
+    public function getAccessToken()
+    {
         return $this->accessToken;
     }
 
     /**
      * @return string
      */
-    public function getRefreshToken() {
+    public function getRefreshToken()
+    {
         return $this->refreshToken;
     }
 
     /**
      * @return string
      */
-    public function getIdToken() {
+    public function getIdToken()
+    {
         return $this->idToken;
     }
 
     /**
      * @return array
      */
-    public function getAccessTokenHeader() {
+    public function getAccessTokenHeader()
+    {
         return $this->decodeJWT($this->accessToken, 0);
     }
 
     /**
      * @return array
      */
-    public function getAccessTokenPayload() {
+    public function getAccessTokenPayload()
+    {
         return $this->decodeJWT($this->accessToken, 1);
     }
 
     /**
      * @return array
      */
-    public function getIdTokenHeader() {
+    public function getIdTokenHeader()
+    {
         return $this->decodeJWT($this->idToken, 0);
     }
 
     /**
      * @return array
      */
-    public function getIdTokenPayload() {
+    public function getIdTokenPayload()
+    {
         return $this->decodeJWT($this->idToken, 1);
     }
     /**
      * @return array
      */
-    public function getTokenResponse() {
+    public function getTokenResponse()
+    {
         return $this->tokenResponse;
     }
 	
@@ -1100,7 +1146,8 @@ class OpenIDConnectClient
      * @param string $nonce
      * @return string
      */
-    protected function setNonce($nonce) {
+    protected function setNonce($nonce)
+    {
         $_SESSION['openid_connect_nonce'] = $nonce;
         return $nonce;
     }
@@ -1110,7 +1157,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getNonce() {
+    protected function getNonce()
+    {
         return $_SESSION['openid_connect_nonce'];
     }
 	
@@ -1119,7 +1167,8 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetNonce() {
+    protected function unsetNonce()
+    {
         unset($_SESSION['openid_connect_nonce']);
     }
 
@@ -1129,7 +1178,8 @@ class OpenIDConnectClient
      * @param string $state
      * @return string
      */
-    protected function setState($state) {
+    protected function setState($state)
+    {
         $_SESSION['openid_connect_state'] = $state;
         return $state;
     }
@@ -1139,7 +1189,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getState() {
+    protected function getState()
+    {
         return $_SESSION['openid_connect_state'];
     }
     
@@ -1148,7 +1199,8 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetState() {
+    protected function unsetState()
+    {
         unset($_SESSION['openid_connect_state']);
     }
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -591,25 +591,24 @@ class OpenIDConnectClient
       */
      private function get_key_for_header($keys, $header)
      {
-         foreach ($keys as $key) {
-             if ($key->kty == 'RSA') {
-                 if (!isset($header->kid) || $key->kid == $header->kid) {
-                     return $key;
-                 }
-             } else {
-                 if ($key->alg == $header->alg && $key->kid == $header->kid) {
-                     return $key;
-                 }
-             }
-         }
-         if (isset($header->kid)) {
-             throw new OpenIDConnectClientException('Unable to find a key for (algorithm, kid):' . $header->alg . ', ' . $header->kid . ')');
-         } else {
-             throw new OpenIDConnectClientException('Unable to find a key for RSA');
-         }
-     }
-
-
+        foreach ($keys as $key) {
+            if ($key->kty == 'RSA') {
+                if (!isset($header->kid) || $key->kid == $header->kid) {
+                    return $key;
+                }
+            } else {
+                if ($key->alg == $header->alg && $key->kid == $header->kid) {
+                    return $key;
+                }
+            }
+        }
+        if (isset($header->kid)) {
+            throw new OpenIDConnectClientException('Unable to find a key for (algorithm, kid):' .
+                $header->alg . ', ' . $header->kid . ')');
+        } else {
+            throw new OpenIDConnectClientException('Unable to find a key for RSA');
+        }
+    }
 
     /**
      * @param string $hashtype
@@ -633,17 +632,17 @@ class OpenIDConnectClient
             "  <Modulus>" . b64url2b64($key->n) . "</Modulus>\r\n" .
             "  <Exponent>" . b64url2b64($key->e) . "</Exponent>\r\n" .
             "</RSAKeyValue>";
-	if(class_exists('Crypt_RSA')) {
-        	$rsa = new Crypt_RSA();
-		$rsa->setHash($hashtype);
-        	$rsa->loadKey($public_key_xml, Crypt_RSA::PUBLIC_FORMAT_XML);
-        	$rsa->signatureMode = Crypt_RSA::SIGNATURE_PKCS1;
-	} else {
-		$rsa = new \phpseclib\Crypt\RSA();
-		$rsa->setHash($hashtype);
-        	$rsa->loadKey($public_key_xml, \phpseclib\Crypt\RSA::PUBLIC_FORMAT_XML);
-        	$rsa->signatureMode = \phpseclib\Crypt\RSA::SIGNATURE_PKCS1;
-	}
+        if (class_exists('Crypt_RSA')) {
+            $rsa = new Crypt_RSA();
+            $rsa->setHash($hashtype);
+            $rsa->loadKey($public_key_xml, Crypt_RSA::PUBLIC_FORMAT_XML);
+            $rsa->signatureMode = Crypt_RSA::SIGNATURE_PKCS1;
+        } else {
+            $rsa = new \phpseclib\Crypt\RSA();
+            $rsa->setHash($hashtype);
+            $rsa->loadKey($public_key_xml, \phpseclib\Crypt\RSA::PUBLIC_FORMAT_XML);
+            $rsa->signatureMode = \phpseclib\Crypt\RSA::SIGNATURE_PKCS1;
+        }
         return $rsa->verify($payload, $signature);
     }
 
@@ -664,17 +663,20 @@ class OpenIDConnectClient
         }
         $verified = false;
         switch ($header->alg) {
-        case 'RS256':
-        case 'RS384':
-        case 'RS512':
-            $hashtype = 'sha' . substr($header->alg, 2);
+            case 'RS256':
+            case 'RS384':
+            case 'RS512':
+                $hashtype = 'sha' . substr($header->alg, 2);
 
-            $verified = $this->verifyRSAJWTsignature($hashtype,
-                                                     $this->get_key_for_header($jwks->keys, $header),
-                                                     $payload, $signature);
-            break;
-        default:
-            throw new OpenIDConnectClientException('No support for signature type: ' . $header->alg);
+                $verified = $this->verifyRSAJWTsignature(
+                    $hashtype,
+                    $this->get_key_for_header($jwks->keys, $header),
+                    $payload,
+                    $signature
+                );
+                break;
+            default:
+                throw new OpenIDConnectClientException('No support for signature type: ' . $header->alg);
         }
         return $verified;
     }
@@ -685,10 +687,10 @@ class OpenIDConnectClient
      */
     private function verifyJWTclaims($claims, $accessToken = null)
     {
-        if(isset($claims->at_hash) && isset($accessToken)){
-            if(isset($this->getAccessTokenHeader()->alg) && $this->getAccessTokenHeader()->alg != 'none'){
+        if (isset($claims->at_hash) && isset($accessToken)) {
+            if (isset($this->getAccessTokenHeader()->alg) && $this->getAccessTokenHeader()->alg != 'none') {
                 $bit = substr($this->getAccessTokenHeader()->alg, 2, 3);
-            }else{
+            } else {
                 // TODO: Error case. throw exception???
                 $bit = '256';
             }
@@ -703,7 +705,7 @@ class OpenIDConnectClient
             && ( !isset($claims->at_hash) || $claims->at_hash == $expecte_at_hash )
         );
     }
-	
+    
     /**
      * @param string $str
      * @return string
@@ -765,13 +767,13 @@ class OpenIDConnectClient
         //The accessToken has to be send in the Authorization header, so we create a new array with only this header.
         $headers = array("Authorization: Bearer {$this->accessToken}");
 
-        $user_json = json_decode($this->fetchURL($user_info_endpoint,null,$headers));
+        $user_json = json_decode($this->fetchURL($user_info_endpoint, null, $headers));
 
         $this->userInfo = $user_json;
 
-        if($attribute === null) {
+        if ($attribute === null) {
             return $this->userInfo;
-        } else if (array_key_exists($attribute, $this->userInfo)) {
+        } elseif (array_key_exists($attribute, $this->userInfo)) {
             return $this->userInfo->$attribute;
         } else {
             return null;
@@ -785,7 +787,7 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return mixed
      */
-    protected function fetchURL($url, $post_body = null,$headers = array())
+    protected function fetchURL($url, $post_body = null, $headers = array())
     {
         // OK cool - then let's create a new cURL resource handle
         $ch = curl_init();
@@ -793,7 +795,7 @@ class OpenIDConnectClient
         // Determine whether this is a GET or POST
         if ($post_body != null) {
             // curl_setopt($ch, CURLOPT_POST, 1);
-	    // Alows to keep the POST method even after redirect
+            // Alows to keep the POST method even after redirect
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
             curl_setopt($ch, CURLOPT_POSTFIELDS, $post_body);
 
@@ -808,12 +810,11 @@ class OpenIDConnectClient
             // Add POST-specific headers
             $headers[] = "Content-Type: {$content_type}";
             $headers[] = 'Content-Length: ' . strlen($post_body);
-
         }
 
         // If we set some heaers include them
-        if(count($headers) > 0) {
-          curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        if (count($headers) > 0) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         }
 
         // Set URL to download
@@ -825,10 +826,10 @@ class OpenIDConnectClient
 
         // Include header in result? (0 = yes, 1 = no)
         curl_setopt($ch, CURLOPT_HEADER, 0);
-	
-	// Allows to follow redirect
+        
+        // Allows to follow redirect
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-	    
+        
         /**
          * Set cert
          * Otherwise ignore SSL peer verification
@@ -837,16 +838,16 @@ class OpenIDConnectClient
             curl_setopt($ch, CURLOPT_CAINFO, $this->certPath);
         }
         
-        if($this->verifyHost) {
+        if ($this->verifyHost) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         }
         
-        if($this->verifyPeer) {
+        if ($this->verifyPeer) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         } else {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);        
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
         
         // Should cURL return or print out the data? (true = return, false = print)
@@ -1001,7 +1002,8 @@ class OpenIDConnectClient
 
         // Throw some errors if we encounter them
         if ($json_response === false) {
-            throw new OpenIDConnectClientException("Error registering: JSON response received from the server was invalid.");
+            throw new OpenIDConnectClientException("Error registering: 
+                JSON response received from the server was invalid.");
         } elseif (isset($json_response->{'error_description'})) {
             throw new OpenIDConnectClientException($json_response->{'error_description'});
         }
@@ -1014,9 +1016,8 @@ class OpenIDConnectClient
             $this->setClientSecret($json_response->{'client_secret'});
         } else {
             throw new OpenIDConnectClientException("Error registering:
-                                                    Please contact the OpenID Connect provider and obtain a Client ID and Secret directly from them");
+                Please contact the OpenID Connect provider and obtain a Client ID and Secret directly from them");
         }
-
     }
 
     /**
@@ -1056,7 +1057,7 @@ class OpenIDConnectClient
      */
     public function canVerifySignatures()
     {
-      return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
+        return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
     /**
@@ -1135,7 +1136,7 @@ class OpenIDConnectClient
     {
         return $this->tokenResponse;
     }
-	
+    
     /**
      * Stores nonce
      *
@@ -1149,7 +1150,7 @@ class OpenIDConnectClient
     }
     
     /**
-     * Get stored nonce 
+     * Get stored nonce
      *
      * @return string
      */
@@ -1157,9 +1158,9 @@ class OpenIDConnectClient
     {
         return $_SESSION['openid_connect_nonce'];
     }
-	
+    
     /**
-     * Cleanup nonce 
+     * Cleanup nonce
      *
      * @return void
      */
@@ -1181,7 +1182,7 @@ class OpenIDConnectClient
     }
     
     /**
-     * Get stored state 
+     * Get stored state
      *
      * @return string
      */
@@ -1191,7 +1192,7 @@ class OpenIDConnectClient
     }
     
     /**
-     * Cleanup state 
+     * Cleanup state
      *
      * @return void
      */

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -64,7 +64,7 @@ function b64url2b64($base64url)
     // "Shouldn't" be necessary, but why not
     $padding = strlen($base64url) % 4;
     if ($padding > 0) {
-	$base64url .= str_repeat("=", 4 - $padding);
+        $base64url .= str_repeat("=", 4 - $padding);
     }
     return strtr($base64url, '-_', '+/');
 }
@@ -146,12 +146,12 @@ class OpenIDConnectClient
      */
     private $refreshToken;
 
-    /** 
+    /**
      * @var string if we acquire an id token it will be stored here
      */
     private $idToken;
 
-    /** 
+    /**
      * @var string stores the token response
      */
     private $tokenResponse;
@@ -231,7 +231,6 @@ class OpenIDConnectClient
 
         // If we have an authorization code then proceed to request a token
         if (isset($_REQUEST["code"])) {
-
             $code = $_REQUEST["code"];
             $token_json = $this->requestTokens($code);
 
@@ -247,9 +246,9 @@ class OpenIDConnectClient
             if ($_REQUEST['state'] != $this->getState()) {
                 throw new OpenIDConnectClientException("Unable to determine state");
             }
-		
-	    // Cleanup state
-	    $this->unsetState();
+        
+            // Cleanup state
+            $this->unsetState();
 
             if (!property_exists($token_json, 'id_token')) {
                 throw new OpenIDConnectClientException("User did not authorize openid scope.");
@@ -259,11 +258,12 @@ class OpenIDConnectClient
 
             // Verify the signature
             if ($this->canVerifySignatures()) {
-		if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException ("Unable to verify signature due to no jwks_uri being defined");
+                if (!$this->getProviderConfigValue('jwks_uri')) {
+                    throw new OpenIDConnectClientException(
+                            "Unable to verify signature due to no jwks_uri being defined");
                 }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
-                    throw new OpenIDConnectClientException ("Unable to verify signature");
+                    throw new OpenIDConnectClientException("Unable to verify signature");
                 }
             } else {
                 user_error("Warning: JWT signature verification unavailable.");
@@ -271,11 +271,10 @@ class OpenIDConnectClient
 
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
-
                 // Clean up the session a little
                 $this->unsetNonce();
 
-		// Save the full response
+                // Save the full response
                 $this->tokenResponse = $token_json;
 
                 // Save the id token
@@ -285,21 +284,18 @@ class OpenIDConnectClient
                 $this->accessToken = $token_json->access_token;
 
                 // Save the refresh token, if we got one
-                if (isset($token_json->refresh_token)) $this->refreshToken = $token_json->refresh_token;
+                if (isset($token_json->refresh_token))
+                    $this->refreshToken = $token_json->refresh_token;
 
                 // Success!
                 return true;
-
             } else {
-                throw new OpenIDConnectClientException ("Unable to verify JWT claims");
+                throw new OpenIDConnectClientException("Unable to verify JWT claims");
             }
-
         } else {
-
             $this->requestAuthorization();
             return false;
         }
-
     }
 
     /**
@@ -318,16 +314,16 @@ class OpenIDConnectClient
         $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
-        if($redirect == null){
-          $signout_params = array('id_token_hint' => $accessToken);
-        }
-        else {
-          $signout_params = array(
+        if ($redirect == null) {
+            $signout_params = array('id_token_hint' => $accessToken);
+        } else {
+            $signout_params = array(
                 'id_token_hint' => $accessToken,
                 'post_logout_redirect_uri' => $redirect);
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, null, '&');
+        $signout_endpoint .= (strpos($signout_endpoint, '?') === false ? '?' : '&') .
+                http_build_query($signout_params, null, '&');
         $this->redirect($signout_endpoint);
     }
 
@@ -358,39 +354,36 @@ class OpenIDConnectClient
      */
     private function getProviderConfigValue($param, $default = null)
     {
-
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
         if (!isset($this->providerConfig[$param])) {
-	    if(!$this->wellKnown){
-            	$well_known_config_url = rtrim($this->getProviderURL(),"/") . "/.well-known/openid-configuration";
-            	$this->wellKnown = json_decode($this->fetchURL($well_known_config_url));
-	    }
+            if (!$this->wellKnown) {
+                $well_known_config_url = rtrim($this->getProviderURL(), "/") . "/.well-known/openid-configuration";
+                $this->wellKnown = json_decode($this->fetchURL($well_known_config_url));
+            }
 
-	    $value = false;
-	    if(isset($this->wellKnown->{$param})){
+            $value = false;
+            if (isset($this->wellKnown->{$param})) {
                 $value = $this->wellKnown->{$param};
-            }	
-	    
+            }
             if ($value) {
                 $this->providerConfig[$param] = $value;
-            } elseif(isset($default)) {
+            } elseif (isset($default)) {
                 // Uses default value if provided
                 $this->providerConfig[$param] = $default;
             } else {
-                throw new OpenIDConnectClientException("The provider {$param} has not been set. Make sure your provider has a well known configuration available.");
+                throw new OpenIDConnectClientException("The provider {$param} has not been set.".
+                        " Make sure your provider has a well known configuration available.");
             }
-
         }
 
         return $this->providerConfig[$param];
     }
 
-
     /**
      * @param $url Sets redirect URL for auth flow
      */
-    public function setRedirectURL ($url)
+    public function setRedirectURL($url)
     {
         if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
             $this->redirectURL = $url;
@@ -423,13 +416,13 @@ class OpenIDConnectClient
          * Support of 'ProxyReverse' configurations.
          */
 
-        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) { 
-            $protocol = 'https'; 
-        } else { 
+        if (isset($_SERVER["HTTP_UPGRADE_INSECURE_REQUESTS"]) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] == 1)) {
+            $protocol = 'https';
+        } else {
             $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
-                ?: @$_SERVER['REQUEST_SCHEME'] 
-                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http"); 
-        } 
+                ?: @$_SERVER['REQUEST_SCHEME']
+                ?: ((isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") ? "https" : "http");
+        }
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
               ?: @intval($_SERVER["SERVER_PORT"])
@@ -441,7 +434,8 @@ class OpenIDConnectClient
 
         $port = (443 == $port) || (80 == $port) ? '' : ':' . $port;
 
-        return sprintf('%s://%s%s/%s', $protocol, $host, $port, @trim(reset(explode("?", $_SERVER['REQUEST_URI'])), '/'));
+        return sprintf('%s://%s%s/%s', $protocol, $host, $port, 
+                @trim(reset(explode("?", $_SERVER['REQUEST_URI'])), '/'));
     }
 
     /**

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -589,7 +589,7 @@ class OpenIDConnectClient
       * @throws OpenIDConnectClientException
       * @return object
       */
-     private function get_key_for_header($keys, $header)
+     private function getKeyForHeader($keys, $header)
      {
         foreach ($keys as $key) {
             if ($key->kty == 'RSA') {
@@ -670,7 +670,7 @@ class OpenIDConnectClient
 
                 $verified = $this->verifyRSAJWTsignature(
                     $hashtype,
-                    $this->get_key_for_header($jwks->keys, $header),
+                    $this->getKeyForHeader($jwks->keys, $header),
                     $payload,
                     $signature
                 );

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -260,7 +260,8 @@ class OpenIDConnectClient
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
                     throw new OpenIDConnectClientException(
-                            "Unable to verify signature due to no jwks_uri being defined");
+                    "Unable to verify signature due to no jwks_uri being defined"
+                    );
                 }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
                     throw new OpenIDConnectClientException("Unable to verify signature");
@@ -284,8 +285,9 @@ class OpenIDConnectClient
                 $this->accessToken = $token_json->access_token;
 
                 // Save the refresh token, if we got one
-                if (isset($token_json->refresh_token))
+                if (isset($token_json->refresh_token)) {
                     $this->refreshToken = $token_json->refresh_token;
+                }
 
                 // Success!
                 return true;
@@ -434,8 +436,8 @@ class OpenIDConnectClient
 
         $port = (443 == $port) || (80 == $port) ? '' : ':' . $port;
 
-        return sprintf('%s://%s%s/%s', $protocol, $host, $port, 
-                @trim(reset(explode("?", $_SERVER['REQUEST_URI'])), '/'));
+        $path = @trim(reset(explode("?", $_SERVER['REQUEST_URI'])), '/');
+        return sprintf('%s://%s%s/%s', $protocol, $host, $port, $path);
     }
 
     /**


### PR DESCRIPTION
As specified in issue #57 - added PSR-2 tests using Travis.

Notes:
- Currently, as the code is not PSR-2 compliant, this test fails - as can be seen here: https://travis-ci.org/guss77/OpenID-Connect-PHP .
- This PR depends on PR #88 . It can be made to be standalone if it is required.
- The test does not run on PHP 5.4, as we use Phing which deps on Symphony that requires 5.5. As 5.4 as well as 5.5 are EOLed anyway, I recommend increased the requirement to 5.6.
- The test is using PHP_CodeSniffer 2.9 because 3.0 is not working well under Phing, and - at least that version - doesn't seem to implement PSR-2 correctly and complains about valid things. I'm investigating.