### PR TITLE
Fixed missing use in sample PHP code

### DIFF
--- a/client_example.php
+++ b/client_example.php
@@ -23,6 +23,8 @@
 
 require "../../autoload.php";
 
+use Jumbojett\OpenIDConnectClient;
+
 $oidc = new OpenIDConnectClient('http://myproviderURL.com/',
                                 'ClientIDHere',
                                 'ClientSecretHere');


### PR DESCRIPTION
After the namespace change, the README was modified for that, but not the sample PHP code in client_example.php.