### PR TITLE
Fixed namespacing bug with \Exception

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -71,7 +71,7 @@ function b64url2b64($base64url) {
 /**
  * OpenIDConnect Exception Class
  */
-class OpenIDConnectClientException extends Exception
+class OpenIDConnectClientException extends \Exception
 {
 
 }


### PR DESCRIPTION
With commit 8bf98338e918d0c4e7c27b3d4c545cba5f33f635 a bug was introduced which is fixed by this commit. When using a namespace the default PHP classes should be addressed on the global namespace by using \Exception instead of Exception.