### PR TITLE
update setRedirectUrl valid URL check.

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -386,7 +386,7 @@ class OpenIDConnectClient
      * @param string $url Sets redirect URL for auth flow
      */
     public function setRedirectURL ($url) {
-        if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
+        if (parse_url($url,PHP_URL_HOST) !== false) {
             $this->redirectURL = $url;
         }
     }


### PR DESCRIPTION
In my case i have a redirectURL with an underscore (_). The filter_Validate_url check doesn't allow domains with an underscore.

According to https://stackoverflow.com/questions/39539468/php-filter-validate-url-not-finding-subdomains-with-underscore

parse_url is also better because it uses RFC3986 which is what is currently in effect. In contrast FILTER_VALIDATE_URL uses RFC2396 which is obsolete.