### PR TITLE
 Add support for HS256, HS512 and HS384 signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Timeout is configurable via setTimeout method. This addresses issue #94.
 * Add the ability to authenticate using the Resource Owner flow (with or without the Client ID and ClientSecret). This addresses issue #98
+* Add support for HS256, HS512 and HS384 signatures
 
 ### Changed
 


### PR DESCRIPTION
This extends the verifyJWTsignature method to support HMAC signatures using the client secret as the key.

Also added a cryptographically safe hashEquals static method in case hash_equals is not supported