### PR TITLE
Fix for issue #77

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -493,7 +493,6 @@ class OpenIDConnectClient
      */
     public function requestClientCredentialsToken() {
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
-        $token_endpoint_auth_methods_supported = $this->getProviderConfigValue("token_endpoint_auth_methods_supported");
 
         $headers = [];
 
@@ -521,7 +520,6 @@ class OpenIDConnectClient
      */
     public function requestResourceOwnerToken($bClientAuth =  FALSE) {
         $token_endpoint = $this->getProviderConfigValue("token_endpoint");
-        $token_endpoint_auth_methods_supported = $this->getProviderConfigValue("token_endpoint_auth_methods_supported");
 
         $headers = [];
 


### PR DESCRIPTION
This removes two unnecessary calls to `$this->getProviderConfigValue("token_endpoint_auth_methods_supported");` reported by 	@asmarius  in issue #77 
