### PR TITLE
 updated signature verification in authenticate method

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -228,7 +228,7 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    public function authenticate() {
+    public function authenticate($signature_verification = self::OPTIONAL_SIGNATURE_VERIFICATION) {
 
         // Do a preemptive check to see if the provider has thrown an error from a previous redirect
         if (isset($_REQUEST['error'])) {


### PR DESCRIPTION
Previous behaviour:
If RSA is available try to check signature. Fails, if jwks_uri is not provided.

However, providing JSON Web Keys is cumbersome; especially for test purposes it is nice to be able to bypass this.
New behaviour:
If jwks_uri is missing, an Exception is only thrown when FORCE_SIGNATURE_VERIFICATION is passed. Maybe we should make this default.

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
