### PR TITLE
Implement Azure AD B2C Implicit Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ $token = $oidc->requestResourceOwnerToken(TRUE)->access_token;
 
 ```
 
+## Example 6: Basic client for implicit flow e.g. with Azure AD B2C (see http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth) ##
+
+```php
+use Jumbojett\OpenIDConnectClient;
+
+$oidc = new OpenIDConnectClient('https://id.provider.com',
+                                'ClientIDHere',
+                                'ClientSecretHere');
+$oidc->setResponseTypes(array('id_token'));
+$oidc->addScope(array('openid'));
+$oidc->setAllowImplicitFlow(true);
+$oidc->addAuthParam(array('response_mode' => 'form_post'));
+$oidc->setCertPath('/path/to/my.cert');
+$oidc->authenticate();
+$sub = $oidc->getVerifiedClaims('sub');
+
+```
+
 
 ## Development Environments ##
 In some cases you may need to disable SSL security on on your development systems.

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -348,7 +348,7 @@ class OpenIDConnectClient
                 $this->unsetNonce();
 
                 // Save the id token
-                $this->idToken = $token_json->id_token;
+                $this->idToken = $id_token;
 
                 // Save the verified claims
                 $this->verifiedClaims = $claims;

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1061,7 +1061,7 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getWellKnownIssuer($appendSlash) {
+    public function getWellKnownIssuer($appendSlash = false) {
 
         return $this->getWellKnownConfigValue('issuer') . ($appendSlash ? '/' : '');
     }


### PR DESCRIPTION
Changes to enable the implicit OpenID connect workflow (http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth) of Azure AD B2C.
Claims are verified by and can be retrivied from the id_token.

For the JWT verification in Azure AD B2C the well-known issuer has to be used (with an added slash). This could also be made optional.