### PR TITLE
refreshToken method update

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -698,7 +698,11 @@ class OpenIDConnectClient
         $token_params = http_build_query($token_params, null, '&');
 
         $json = json_decode($this->fetchURL($token_endpoint, $token_params));
-        $this->refreshToken = $json->refresh_token;
+        $this->accessToken = $json->access_token;
+
+        if (isset($json->refresh_token)) {
+            $this->refreshToken = $json->refresh_token;
+        }
 
         return $json;
     }


### PR DESCRIPTION
Some providers do not provide a new refresh token after requesting a new access token with grant_type='refresh_token', for example Google, so the returned json doesnt have a refresh token field, which results in exception

Also added a line to save access token, just like it does in the authenticate() method
