### PR TITLE
verifyJWTsignature() method private -> public

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -821,7 +821,7 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return bool
      */
-    private function verifyJWTsignature($jwt) {
+    public function verifyJWTsignature($jwt) {
         $parts = explode(".", $jwt);
         $signature = base64url_decode(array_pop($parts));
         $header = json_decode(base64url_decode($parts[0]));


### PR DESCRIPTION
In some case we just need to verify the signature of the JWT.

(Ex: frontend which send a request with the JWT (Autorization Header) to a backend, 
the backend can't trust the frontend and must verify the validity of the JWT signature.)

It's a helper to have directly  access to the method verifyJWTsignature().

More information:

https://developers.google.com/identity/protocols/OpenIDConnect#validatinganidtoken
