### PR TITLE
 Leeway due to clock skew when checking exp and nbf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+* Added five minutes leeway due to clock skew between openidconnect server and client.
 * verifyJWTsignature() method private -> public #126
 * Support for providers where provider/login URL is not the same as the issuer URL. #125
 * Support for providers that has a different login URL from the issuer URL, for instance Azure Active Directory. Here, the provider URL is on the format: https://login.windows.net/(tenant-id), while the issuer claim actually is on the format: https://sts.windows.net/(tenant-id).

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -190,6 +190,11 @@ class OpenIDConnectClient
     protected $timeOut = 60;
 
     /**
+     * @var int leeway (seconds)
+     */
+    private $leeway = 300;
+	
+    /**
      * @var array holds response types
      */
     private $additionalJwks = array();
@@ -871,8 +876,8 @@ class OpenIDConnectClient
         return (($claims->iss == $this->getIssuer() || $claims->iss == $this->getWellKnownIssuer() || $claims->iss == $this->getWellKnownIssuer(true))
             && (($claims->aud == $this->clientID) || (in_array($this->clientID, $claims->aud)))
             && ($claims->nonce == $this->getNonce())
-            && ( !isset($claims->exp) || $claims->exp >= time())
-            && ( !isset($claims->nbf) || $claims->nbf <= time())
+            && ( !isset($claims->exp) || $claims->exp >= time() - $this->leeway)
+            && ( !isset($claims->nbf) || $claims->nbf <= time() + $this->leeway)
             && ( !isset($claims->at_hash) || $claims->at_hash == $expecte_at_hash )
         );
     }


### PR DESCRIPTION
If the openidconnet server and the openidconnect client are different machines, little time diffs cause a 500 Internal Server Error on the client. The openid-connect-php throws an exception in this case.

To handle this error, the client should add a leeway due to these time differences.
