### PR TITLE
Decouple session manipulation, it's allow use of other session libraries

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -24,13 +24,6 @@
 namespace Jumbojett;
 
 /**
- * Use session to manage a nonce
- */
-if (!isset($_SESSION)) {
-    @session_start();
-}
-
-/**
  *
  * JWT signature verification support by Jonathan Reed <jdreed@mit.edu>
  * Licensed under the same license as the rest of this file.
@@ -595,7 +588,7 @@ class OpenIDConnectClient
 
         $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, null, '&');
 
-        session_commit();
+        $this->commitSession();
         $this->redirect($auth_endpoint);
     }
 
@@ -1358,7 +1351,7 @@ class OpenIDConnectClient
      * @return string
      */
     protected function setNonce($nonce) {
-        $_SESSION['openid_connect_nonce'] = $nonce;
+        $this->setSessionKey('openid_connect_nonce', $nonce);
         return $nonce;
     }
 
@@ -1368,7 +1361,7 @@ class OpenIDConnectClient
      * @return string
      */
     protected function getNonce() {
-        return $_SESSION['openid_connect_nonce'];
+        return $this->getSessionKey('openid_connect_nonce');
     }
 
     /**
@@ -1377,7 +1370,7 @@ class OpenIDConnectClient
      * @return void
      */
     protected function unsetNonce() {
-        unset($_SESSION['openid_connect_nonce']);
+        $this->unsetSessionKey('openid_connect_nonce');
     }
 
     /**
@@ -1387,7 +1380,7 @@ class OpenIDConnectClient
      * @return string
      */
     protected function setState($state) {
-        $_SESSION['openid_connect_state'] = $state;
+        $this->setSessionKey('openid_connect_state', $state);
         return $state;
     }
 
@@ -1397,7 +1390,7 @@ class OpenIDConnectClient
      * @return string
      */
     protected function getState() {
-        return $_SESSION['openid_connect_state'];
+        return $this->getSessionKey('openid_connect_state');
     }
 
     /**
@@ -1406,7 +1399,7 @@ class OpenIDConnectClient
      * @return void
      */
     protected function unsetState() {
-        unset($_SESSION['openid_connect_state']);
+        $this->unsetSessionKey('openid_connect_state');
     }
 
     /**
@@ -1467,5 +1460,38 @@ class OpenIDConnectClient
         //if strings were different lengths, we fail
         $status |= ($len1 ^ $len2);
         return ($status === 0);
+    }
+
+    /**
+     * Use session to manage a nonce
+     */
+    protected function startSession() {
+        if (!isset($_SESSION)) {
+            @session_start();
+        }
+    }
+
+    protected function commitSession() {
+        $this->startSession();
+
+        session_commit();
+    }
+
+    protected function getSessionKey($key) {
+        $this->startSession();
+
+        return $_SESSION[$key];
+    }
+
+    protected function setSessionKey($key, $value) {
+        $this->startSession();
+
+        $_SESSION[$key] = $value;
+    }
+
+    protected function unsetSessionKey($key) {
+        $this->startSession();
+
+        unset($_SESSION[$key]);
     }
 }


### PR DESCRIPTION
It's is necessary for allow integration of this package with frameworks, because the session storage may be other than native, example, redis.

Encapsulating session manipulations in methods allow override them in a child class.

Please, release a version with this feature.

**Changelog**
- Not autostart session on include the class file, only when session manipulation is necessary
- New protected methods to manipulate session data
