### PR TITLE
Add error handling for invalid or incomplete token in verifyJWTsignature() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-* 
+* Fix `verifyJWTsignature()`: verify JWT to prevent php errors and warnings on invalid token
+*
 
 ### Changed
 * 


### PR DESCRIPTION
The method `verifyJWTsignature()` could run into several php errors and warnings, if the token (`$jwt`) is invalid or incomplete. This fix checks the token and interim results and throws `OpenIDConnectClientException` if something is wrong.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
