### PR TITLE
Broadens version requirements of the phpseclib/phpseclib package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "phpseclib/phpseclib" : "2.0.1",
+        "phpseclib/phpseclib" : "~2.0",
         "ext-json": "*",
         "ext-curl": "*"
     },


### PR DESCRIPTION
There is no reason to be locking to a specific phpseclib version. This denies the package consumers important patches and fixes.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
