### PR TITLE
Updated OpenIDConnectClient to conditionally verify nonce

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -898,7 +898,8 @@ class OpenIDConnectClient
         }
         return (($claims->iss == $this->getIssuer() || $claims->iss == $this->getWellKnownIssuer() || $claims->iss == $this->getWellKnownIssuer(true))
             && (($claims->aud == $this->clientID) || (in_array($this->clientID, $claims->aud)))
-            && ($claims->nonce == $this->getNonce())
+	    // Nonce can be optionally returned, only validate if we have it 	
+            && ( !isset($claims->nonce) || $claims->nonce == $this->getNonce())
             && ( !isset($claims->exp) || $claims->exp >= time() - $this->leeway)
             && ( !isset($claims->nbf) || $claims->nbf <= time() + $this->leeway)
             && ( !isset($claims->at_hash) || $claims->at_hash == $expecte_at_hash )


### PR DESCRIPTION
In order to comply with theopenid connect spec, verifyJWTclaims method within the client needs to check a nonce is set, and only verifies if it does. See: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
