### PR TITLE
Make compatible with the LDS OpenIDConnect system

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -962,8 +962,10 @@ class OpenIDConnectClient
 
         $user_info_endpoint .= "?schema=" . $schema;
 
-        //The accessToken has to be send in the Authorization header, so we create a new array with only this header.
-        $headers = array("Authorization: Bearer {$this->accessToken}");
+        //The accessToken has to be sent in the Authorization header.
+	// Accept json to indicate response type
+        $headers = ["Authorization: Bearer {$this->accessToken}", 
+                    "Accept: application/json"];
 
         $user_json = json_decode($this->fetchURL($user_info_endpoint,null,$headers));
 


### PR DESCRIPTION
The spec indicates that a JWT or a JSON response type can be made for the userinfo endpoint. Accept headers will indicate that we prefer to handle that type.

I'm not sure if the library could detect the response type and handle either, but simply adding the Accept header with 'application/json' is sufficient to get a JSON response type from the endpoint for LDS, making jumbojett/OpenID-Connect-PHP work.
