### PR TITLE
Revert "Updated OpenIDConnectClient to conditionally verify nonce"

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -898,8 +898,7 @@ class OpenIDConnectClient
         }
         return (($claims->iss == $this->getIssuer() || $claims->iss == $this->getWellKnownIssuer() || $claims->iss == $this->getWellKnownIssuer(true))
             && (($claims->aud == $this->clientID) || (in_array($this->clientID, $claims->aud)))
-	    // Nonce can be optionally returned, only validate if we have it 	
-            && ( !isset($claims->nonce) || $claims->nonce == $this->getNonce())
+            && ($claims->nonce == $this->getNonce())
             && ( !isset($claims->exp) || $claims->exp >= time() - $this->leeway)
             && ( !isset($claims->nbf) || $claims->nbf <= time() + $this->leeway)
             && ( !isset($claims->at_hash) || $claims->at_hash == $expecte_at_hash )


### PR DESCRIPTION
Reverts jumbojett/OpenID-Connect-PHP#146

After reviewing @sbusch input and consulting the spec this should be reverted. Even though the _nonce_ is optional the spec states the following:

>If a nonce value was sent in the Authentication Request, a nonce Claim MUST be present and its value checked to verify that it is the same value as the one that was sent in the Authentication Request. The Client SHOULD check the nonce value for replay attacks. The precise method for detecting replay attacks is Client specific.