### PR TITLE
Add optional parameters clientId/clientSecret for introspection

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -424,7 +424,7 @@ class OpenIDConnectClient
                 'post_logout_redirect_uri' => $redirect);
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, null, '&', $this->$enc_type);
+        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, null, '&', $this->enc_type);
         $this->redirect($signout_endpoint);
     }
 
@@ -612,7 +612,7 @@ class OpenIDConnectClient
             $auth_params = array_merge($auth_params, array('response_type' => implode(' ', $this->responseTypes)));
         }
 
-        $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, null, '&', $this->$enc_type);
+        $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, null, '&', $this->enc_type);
 
         $this->commitSession();
         $this->redirect($auth_endpoint);
@@ -638,7 +638,7 @@ class OpenIDConnectClient
         );
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->$enc_type);
+        $post_params = http_build_query($post_data, null, '&', $this->enc_type);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers));
     }
@@ -673,7 +673,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->$enc_type);
+        $post_params = http_build_query($post_data, null, '&', $this->enc_type);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers));
     }
@@ -709,7 +709,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $token_params = http_build_query($token_params, null, '&', $this->$enc_type);
+        $token_params = http_build_query($token_params, null, '&', $this->enc_type);
 
         return json_decode($this->fetchURL($token_endpoint, $token_params, $headers));
 
@@ -735,7 +735,7 @@ class OpenIDConnectClient
         );
 
         // Convert token params to string format
-        $token_params = http_build_query($token_params, null, '&', $this->$enc_type);
+        $token_params = http_build_query($token_params, null, '&', $this->enc_type);
 
         $json = json_decode($this->fetchURL($token_endpoint, $token_params));
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1312,10 +1312,12 @@ class OpenIDConnectClient
      *
      * @param string $token
      * @param string $token_type_hint
+     * @param string|null $clientId
+     * @param string|null $clientSecret
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function introspectToken($token, $token_type_hint = '') {
+    public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {
         $introspection_endpoint = $this->getProviderConfigValue('introspection_endpoint');
 
         $post_data = array(
@@ -1324,10 +1326,12 @@ class OpenIDConnectClient
         if ($token_type_hint) {
             $post_data['token_type_hint'] = $token_type_hint;
         }
+        $clientId = $clientId !== null ? $clientId : $this->clientID;
+        $clientSecret = $clientSecret !== null ? $clientSecret : $this->clientSecret;
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, null, '&');
-        $headers = ['Authorization: Basic ' . base64_encode($this->clientID . ':' . $this->clientSecret),
+        $headers = ['Authorization: Basic ' . base64_encode($clientId . ':' . $clientSecret),
             'Accept: application/json'];
 
         return json_decode($this->fetchURL($introspection_endpoint, $post_params, $headers));


### PR DESCRIPTION
**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality

Seems to be common practice to have a second clientId/clientSecret pair for token introspection.
This adds them as optional parameters to the introspection call.