### PR TITLE
Fix OpenIDConnectClient.php for issue with Safari

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -552,6 +552,12 @@ class OpenIDConnectClient
             $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
                 ?: @$_SERVER['REQUEST_SCHEME']
                     ?: ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http');
+         
+            // with a proxy, and only for Safari, protocol can end up being 'http, https' - which is invalid
+		    if ( strstr( $protocol, ',' ) ) { 
+                $protocol = 'https'; 
+            }
+            
         }
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])


### PR DESCRIPTION
Only with a proxy server, and only with the Safari web browser, the `$protocol` ends up being set to a list 'http, https' which is invalid and thus causes failure "Redirect URI not configured properly'.

With this fix, I'm not rewriting the complex ternary code (because I don't know if I can replicate the setup where these various headers are present. However, I can check if $protocol has a comma in it; and if so just default to 'https' for $protocol.

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
