### PR TITLE
added issuer validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Adding OAuth 2.0 Token Introspection #156
 * Add optional parameters clientId/clientSecret for introspection #157 & #158
 * Adding OAuth 2.0 Token Revocation #160
+* Adding issuer validator #145
 
 ### Changed
 * Bugfix/code cleanup #152


### PR DESCRIPTION
This allows the developer to set a custom validator for the issuer claim.

This is meant to solve the following problem:
Microsoft Azure AD has a Placeholder for the Tenant-ID in its allowed issuer field of the well-known config. Because the authenticate Method only compares the strings it always fails the request.
