### PR TITLE
Add scope param to authorization flow token request

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -708,7 +708,8 @@ class OpenIDConnectClient
             'code' => $code,
             'redirect_uri' => $this->getRedirectURL(),
             'client_id' => $this->clientID,
-            'client_secret' => $this->clientSecret
+            'client_secret' => $this->clientSecret,
+            'scope'         => implode(' ', $this->scopes)
         );
 
         # Consider Basic authentication if provider config is set this way


### PR DESCRIPTION
Noticed that the scope param was missing when requesting a token in the auth code flow.