### PR TITLE
Adding signing algorithm PS256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/vendor
+/composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Add optional parameters clientId/clientSecret for introspection #157 & #158
 * Adding OAuth 2.0 Token Revocation #160
 * Adding issuer validator #145
+* Adding signing algorithm PS256 #180
 
 ### Changed
 * Bugfix/code cleanup #152

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,11 @@
         "php": ">=5.4",
         "phpseclib/phpseclib" : "~2.0",
         "ext-json": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "phpunit/phpunit": "^4.8"
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master"
     },
     "archive" : {
         "exclude" : [
@@ -15,5 +19,10 @@
     },
     "autoload" : {
          "classmap": [ "src/"]
+    },
+  "config" : {
+    "platform": {
+      "php": "5.4"
     }
+  }
 }

--- a/tests/TokenVerificationTest.php
+++ b/tests/TokenVerificationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+
+use Jumbojett\OpenIDConnectClient;
+
+class TokenVerificationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @param $alg
+     * @param $jwt
+     * @throws \Jumbojett\OpenIDConnectClientException
+     * @dataProvider providesTokens
+     */
+    public function testTokenVerification($alg, $jwt)
+    {
+        /** @var OpenIDConnectClient | PHPUnit_Framework_MockObject_MockObject $client */
+        $client = $this->getMockBuilder(OpenIDConnectClient::class)->setMethods(['fetchUrl'])->getMock();
+        $client->method('fetchUrl')->willReturn(file_get_contents(__DIR__ . "/data/jwks-$alg.json"));
+        $client->setProviderURL('https://jwt.io/');
+        $client->providerConfigParam(['jwks_uri' => 'https://jwt.io/.well-known/jwks.json']);
+        $verified = $client->verifyJWTsignature($jwt);
+        self::assertTrue($verified);
+        $client->setAccessToken($jwt);
+    }
+
+    public function providesTokens()
+    {
+        return [
+            'PS256' => ['ps256', 'eyJhbGciOiJQUzI1NiIsImtpZCI6Imtvbm5lY3RkLXRva2Vucy1zaWduaW5nLWtleSIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJrcG9wLWh0dHBzOi8va29wYW5vLmRlbW8vbWVldC8iLCJleHAiOjE1NjgzNzE0NjEsImp0aSI6IkpkR0tDbEdOTXl2VXJpcmlRRUlWUXZCVmttT2FfQkRjIiwiaWF0IjoxNTY4MzcxMjIxLCJpc3MiOiJodHRwczovL2tvcGFuby5kZW1vIiwic3ViIjoiUHpUVWp3NHBlXzctWE5rWlBILXJxVHE0MTQ1Z3lDdlRvQmk4V1E5bFBrcW5rbEc1aktvRU5LM21Qb0I1WGY1ZTM5dFRMR2RKWXBMNEJubXFnelpaX0FAa29ubmVjdCIsImtjLmlzQWNjZXNzVG9rZW4iOnRydWUsImtjLmF1dGhvcml6ZWRTY29wZXMiOlsicHJvZmlsZSIsImVtYWlsIiwia29wYW5vL2t3bSIsImtvcGFuby9nYyIsImtvcGFuby9rdnMiLCJvcGVuaWQiXSwia2MuYXV0aG9yaXplZENsYWltcyI6eyJpZF90b2tlbiI6eyJuYW1lIjpudWxsfX0sImtjLmlkZW50aXR5Ijp7ImtjLmkuZG4iOiJKb25hcyBCcmVra2UiLCJrYy5pLmlkIjoiQUFBQUFLd2hxVkJBMCs1SXN4bjdwMU13UkNVQkFBQUFCZ0FBQUJzQUFBQk5VVDA5QUFBQUFBPT0iLCJrYy5pLnVuIjoidXNlcjEiLCJrYy5pLnVzIjoiTVEifSwia2MucHJvdmlkZXIiOiJpZGVudGlmaWVyLWtjIn0.hGRuXvul2kOiALHexwYp5MBEJVwz1YV3ehyM3AOuwCoK2w5sJxdciqqY_TfXCKyO6nAEbYLK3J0CBOjfup_IG0aCZcwzjto8khYlc4ezXkGnFsbJBNQdDGkpHtWnioWx-OJ3cXvY9F8aOvjaq0gw11ZDAcqQl0g7LTbJ9-J_yx0pmy3NGai2JB30Fh1OgSDzYfxWnE0RRgZG-x68e65RXfSBaEGW85OUh4wihxO2zdTGAHJ3Iq_-QAG4yRbXZtLx3ZspG7LNmqG-YE3huy3Rd8u3xrJNhmUOfEnz3x07q7VW0cj9NedX98BAbj3iNvksQsE0oG0J_f_Tu8Ai8VbWB72sJuXZWxANDKdz0BBYLzXhsjXkNByRq9x3zqDVsX-cVHei_XudxEOVRBjhkvW2MmIjcAHNKCKsdar865-gFG9McP4PCcBlY28tC0Cvnzyi83LBfpGRXdl6MJunnUsKQ1C79iCoVI1doK1erFN959Q-TGJfJA3Tr5LNpuGawB5rpe1nDGWvmYhg3uYfNl8uTTyvNgvvejcflEb2DURuXdqABuSiP7RkDWYtzx6mq49G0tRxelBbvyjQ2id2QjmRRdQ6dHEZ2NCJ51b8OFoDJBtxN1CD62TTxa3FUqCdZAPAUR3hHn_69vYq82MR514s-Gb67A6j2PbMPFATQP2UdK8']
+        ];
+    }
+}

--- a/tests/data/jwks-ps256.json
+++ b/tests/data/jwks-ps256.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "konnectd-tokens-signing-key",
+      "n": "10hb3pFUVcqJcS-d1pLCkFTyTqVD1GavlAai582CoRwFcyIQxCPJz0LJVgkUNwxSRkY0g0PcgFN_MmuuzpFXMkkiMIC9O_KwnuL34FrbijZvcGpnDn7kb9KAM883OVTr_w3wFeQIyh0ksSwVQ9CxVQ-ZeCXP73CCGk99uDb8SeF8_vncXJmaak99pK6HKJteSLkA-Ywxo9HOINZK2vW06UYcSkeoQnSI27Cd5-T6GVgqKH0Su4c5Ydou_w0tL_UkbZA4fIbMZC6dtWmBQf6tyYsCM9fbWNIVOj_7WlWcAOSTFNF2We2dxJrOzt6vDND3k1nCgg_EEM6cgBO3swUCktTFuQxo1sryYX5WXz9wnJb38b9mTXhOeF0bd9y_VQq8erSlcyRu8UGzX65tIf534hLL16KQaHbjROGSQvzqFrISmSBjBTjkPedTZSYOhiVJ95-em_Y6uLi-T7V4bs4dcg3oa0H_glXltoC9JxzS6gfMGGLgh-NpGEOdC_QosyzVVfzT70TurOGnsB1_VcAm_fK-T1Zv_ztpr5OZNfXWXC3Pfq_3sxP5HDKMk8luZ7LOWk7HVSYBdCFmOM1A3KmHNS2fEs-QHIr-XjYQ7QrXsRFP3dmoEPfiYlu03m8Xs3UMB70eGeGQx7OhZSuogxV_oCfApV5EJfuz97tVmOg8iMs",
+      "e": "AQAB"
+    }
+  ],
+  "kty": ""
+}


### PR DESCRIPTION
While integrating with Kopano Konnectd (OpenID Connect Provider of Kopano Groupware) I fell into the case where PS256 is the default signing algorithm. see https://github.com/Kopano-dev/konnect/issues/1

This PR adds PS256 support.

A simplistic unit test was added - basically for local/personal testing to make sure this works.
We can work on unit testing/ci integration in the future ....

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
