### PR TITLE
move phpunit to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
         "php": ">=5.4",
         "phpseclib/phpseclib" : "~2.0",
         "ext-json": "*",
-        "ext-curl": "*",
-        "phpunit/phpunit": "^4.8"
+        "ext-curl": "*"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8",
         "roave/security-advisories": "dev-master"
     },
     "archive" : {


### PR DESCRIPTION
When using this in another project, I am getting problems running `phpunit`. I think it is because `phpunit` here is mentioned as a "normal" dependency and so (possibly old 4.*) `phpunit` stuff is appearing and causing trouble when mixed with the `phpunit` 6 or 7 in the other project repo.

IMO `phpunit` should just be a dev dependency here?