### PR TITLE
php 7.4 deprecates array_key_exists on objects, use property_exists instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+* php 7.4 deprecates array_key_exists on objects, use property_exists in getVerifiedClaims and requestUserInfo
 * Adding a header to indicate JSON as the return type for userinfo endpoint #151
 * ~Updated OpenIDConnectClient to conditionally verify nonce #146~
 * Add possibility to change enc_type parameter for http_build_query #155

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1016,7 +1016,7 @@ class OpenIDConnectClient
             return $this->userInfo;
         }
 
-        if (array_key_exists($attribute, $this->userInfo)) {
+        if (property_exists($this->userInfo, $attribute)) {
             return $this->userInfo->$attribute;
         }
 
@@ -1048,7 +1048,7 @@ class OpenIDConnectClient
             return $this->verifiedClaims;
         }
 
-        if (array_key_exists($attribute, $this->verifiedClaims)) {
+        if (property_exists($this->verifiedClaims, $attribute)) {
             return $this->verifiedClaims->$attribute;
         }
 


### PR DESCRIPTION
Hi there,

php 7.4 deprecates `array_key_exists` on objects, so I've replaced the calls with `property_exists` instead for functions `getVerifiedClaims` and `requestUserInfo`

Unfortunately there are no test files that test the current functionality, but I've tested the changes in PHP 7.4 on my application.

I've also added an entry in the CHANGELOG.md