### PR TITLE
URL encode basic auth user and password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Adding OAuth 2.0 Token Revocation #160
 * Adding issuer validator #145
 * Adding signing algorithm PS256 #180
-* Check http staus of request user info #186
+* Check http status of request user info #186
+* URL encode clientId and clientSecret when using basic authentication, according to https://tools.ietf.org/html/rfc6749#section-2.3.1 #192
 
 ### Changed
 * Bugfix/code cleanup #152

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -713,7 +713,7 @@ class OpenIDConnectClient
 
         # Consider Basic authentication if provider config is set this way
         if (in_array('client_secret_basic', $token_endpoint_auth_methods_supported, true)) {
-            $headers = ['Authorization: Basic ' . base64_encode($this->clientID . ':' . $this->clientSecret)];
+            $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret))];
             unset($token_params['client_secret']);
         }
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1362,7 +1362,7 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, null, '&');
-        $headers = ['Authorization: Basic ' . base64_encode($clientId . ':' . $clientSecret),
+        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
             'Accept: application/json'];
 
         return json_decode($this->fetchURL($introspection_endpoint, $post_params, $headers));
@@ -1393,7 +1393,7 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, null, '&');
-        $headers = ['Authorization: Basic ' . base64_encode($clientId . ':' . $clientSecret),
+        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
             'Accept: application/json'];
 
         return json_decode($this->fetchURL($revocation_endpoint, $post_params, $headers));


### PR DESCRIPTION
URL encode basic auth user and password according to https://tools.ietf.org/html/rfc6749#section-2.3.1

Apparently, this is a commonly missed section in the RFC, and it is not as common to hit this particular one. I just hit this on a (for me) new OIDC server, the previous one did not decode the secret. Unfortunately, I do not know the OIDC servers or versions.

Found a similar PR here: https://github.com/openid/AppAuth-Android/pull/345

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
