### PR TITLE
Add login_hint as optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Check http status of request user info #186
 * URL encode clientId and clientSecret when using basic authentication, according to https://tools.ietf.org/html/rfc6749#section-2.3.1 #192
 * Adjust PHPDoc to state that null is also allowed #193
+* Add optional parameter login_hint
 
 ### Changed
 * Bugfix/code cleanup #152

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -155,6 +155,11 @@ class OpenIDConnectClient
     private $scopes = array();
 
     /**
+     * @var string stores the login hint
+     */
+    private $loginHint;
+
+    /**
      * @var int|null Response code from the server
      */
     private $responseCode;
@@ -255,6 +260,14 @@ class OpenIDConnectClient
      */
     public function setIssuer($issuer) {
         $this->providerConfig['issuer'] = $issuer;
+    }
+
+
+    /**
+     * @param string $loginHint
+     */
+    public function setLoginHint($loginHint) {
+        $this->loginHint = $loginHint;
     }
 
     /**
@@ -619,6 +632,10 @@ class OpenIDConnectClient
         // If the client has been registered with additional response types
         if (count($this->responseTypes) > 0) {
             $auth_params = array_merge($auth_params, array('response_type' => implode(' ', $this->responseTypes)));
+        }
+
+        if ($this->loginHint != '') {
+            $auth_params = array_merge($auth_params, array('login_hint' => $this->loginHint));
         }
 
         $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, null, '&', $this->enc_type);


### PR DESCRIPTION
**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality

Parameter can be used to prefill the login form. From the docs (https://openid.net/specs/openid-connect-core-1_0.html):

> login_hint: OPTIONAL. Hint to the Authorization Server about the login identifier the End-User might use to log in (if necessary). This hint can be used by an RP if it first asks the End-User for their e-mail address (or other identifier) and then wants to pass that value as a hint to the discovered authorization service. It is RECOMMENDED that the hint value match the value used for discovery. This value MAY also be a phone number in the format specified for the phone_number Claim. The use of this parameter is left to the OP's discretion.
