### PR TITLE
Bugfix for failing OpenID when adding scopes using addScope method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   * Fix indent #e9cdf56
   * Cleanup conditional code flow for better readability #107f3fb
  * Added strict type comparisons #167
+* Bugfix: required `openid` scope was omitted when additional scopes were registered using `addScope` method. This resulted in failing OpenID process.
 
 ### Removed
 *

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -613,7 +613,7 @@ class OpenIDConnectClient
 
         // If the client has been registered with additional scopes
         if (count($this->scopes) > 0) {
-            $auth_params = array_merge($auth_params, array('scope' => implode(' ', $this->scopes)));
+            $auth_params = array_merge($auth_params, array('scope' => implode(' ', array_merge($this->scopes, array('openid')))));
         }
 
         // If the client has been registered with additional response types


### PR DESCRIPTION
The openid scope was omitted in case additional scopes where registered using the addScope method. This resulted in failing OpenID process. A new release should be scheduled to make the fix available via packagist.org.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
