### PR TITLE
Removed client ID query parameter when making a token request using Basic Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Fix at_hash verification #200
 * Getters for public parameters #204
+* Removed client ID query parameter when making a token request using Basic Auth
 
 ### Removed
 *

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -715,6 +715,7 @@ class OpenIDConnectClient
         if (in_array('client_secret_basic', $token_endpoint_auth_methods_supported, true)) {
             $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret))];
             unset($token_params['client_secret']);
+	        unset($token_params['client_id']);
         }
 
         // Convert token params to string format


### PR DESCRIPTION
Per the OIDC spec, client ID should not be included as a query parameter when making a token request with Basic Auth. See section 3.1.3.1 

https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
