### PR TITLE
Changelog regarding content-length header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Getters for public parameters #204
 
 ### Removed
-*
+* Removed explicit content-length header - caused issues with proxy servers
 
 
 ## [0.9.0]

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1085,7 +1085,6 @@ class OpenIDConnectClient
 
             // Add POST-specific headers
             $headers[] = "Content-Type: {$content_type}";
-            $headers[] = 'Content-Length: ' . strlen($post_body);
 
         }
 


### PR DESCRIPTION
Since the body isn't sent during the proxy CONNECT, the content-length doesn't match, and the proxy terminates the connection.
This effects servers using curl < 7.42.1.
Some description about the issue described here: https://daniel.haxx.se/blog/2014/04/04/curl-and-proxy-headers/
The curl version in question seems old, but is still the default on versions of RedHat/CentOS up to 7.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
