### PR TITLE
Use ID Token alg to check at_hash

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -323,7 +323,7 @@ class OpenIDConnectClient
             $this->accessToken = $token_json->access_token;
 
             // If this is a valid claim
-            if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
+            if ($this->verifyJWTclaims($claims, $token_json->access_token, $this->decodeJWT($token_json->id_token, 0))) {
 
                 // Clean up the session a little
                 $this->unsetNonce();
@@ -382,7 +382,7 @@ class OpenIDConnectClient
             $this->idToken = $id_token;
 
             // If this is a valid claim
-            if ($this->verifyJWTclaims($claims, $accessToken)) {
+            if ($this->verifyJWTclaims($claims, $accessToken, $this->decodeJWT($id_token, 0))) {
 
                 // Clean up the session a little
                 $this->unsetNonce();
@@ -923,12 +923,13 @@ class OpenIDConnectClient
     /**
      * @param object $claims
      * @param string|null $accessToken
+     * @param object|null $idTokenHeader
      * @return bool
      */
-    protected function verifyJWTclaims($claims, $accessToken = null) {
-        if(isset($claims->at_hash) && isset($accessToken)){
-            if(isset($this->getIdTokenHeader()->alg) && $this->getIdTokenHeader()->alg !== 'none'){
-                $bit = substr($this->getIdTokenHeader()->alg, 2, 3);
+    protected function verifyJWTclaims($claims, $accessToken = null, $idTokenHeader = null) {
+        if(isset($claims->at_hash) && isset($accessToken) && isset($idTokenHeader)){
+            if(isset($idTokenHeader->alg) && $idTokenHeader->alg != 'none'){
+                $bit = substr($idTokenHeader->alg, 2, 3);
             }else{
                 // TODO: Error case. throw exception???
                 $bit = '256';


### PR DESCRIPTION
Hello,

this pull request fixes how the at_hash is checked, to comply to OpenID Connect specification.

See https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
> at_hash
>    OPTIONAL. Access Token hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the access_token value, where the hash algorithm used is the hash algorithm used in the alg Header Parameter of the ID Token's JOSE Header. For instance, if the alg is RS256, hash the access_token value with SHA-256, then take the left-most 128 bits and base64url encode them. The at_hash value is a case sensitive string. 

In current code, the algorithm is taken from access token header, but it must be taken from ID Token header instead.