### PR TITLE
Security fix: Use random_bytes() instead of uniqid()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix at_hash verification #200
 * Getters for public parameters #204
 * Removed client ID query parameter when making a token request using Basic Auth
+* Use of `random_bytes()` for token generation instead of `uniqid()`; polyfill for PHP < 7.0 provided.
 
 ### Removed
 * Removed explicit content-length header - caused issues with proxy servers

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "php": ">=5.4",
         "phpseclib/phpseclib" : "~2.0",
         "ext-json": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "paragonie/random_compat": ">=2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -580,9 +580,18 @@ class OpenIDConnectClient
      * Used for arbitrary value generation for nonces and state
      *
      * @return string
+     * @throws OpenIDConnectClientException
      */
     protected function generateRandString() {
-        return md5(uniqid(rand(), TRUE));
+        // Error and Exception need to be catched in this order, see https://github.com/paragonie/random_compat/blob/master/README.md
+        // random_compat polyfill library should be removed if support for PHP versions < 7 is dropped
+        try {
+            return \bin2hex(\random_bytes(16));
+        } catch (Error $e) {
+            throw new OpenIDConnectClientException('Random token generation failed.');
+        } catch (Exception $e) {
+            throw new OpenIDConnectClientException('Random token generation failed.');
+        };
     }
 
     /**


### PR DESCRIPTION
**This security fix will break compatibility with PHP versions prior to 7.0. But in my opinion, it doesn't matter since these are End-of-Life since more than a year. Anyway, including [random_compat](https://github.com/paragonie/random_compat) may be a solution.**

[RFC 6749](https://tools.ietf.org/html/rfc6749#section-10.12) recommends CSRF protection via `state` parameter. Therefore, its value needs to be cryptographically secure ([uniqid](https://php.net/uniqid) does not provide that). The [OIDC-Spec](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes) states the same for `nonce`:

> The nonce parameter value needs to include per-session state and be unguessable to attackers. One method to achieve this for Web Server Clients is to store a _cryptographically random value_ as an HttpOnly session cookie and use a cryptographic hash of the value as the nonce parameter.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
