### PR TITLE
Add scope parameter to the refreshToken request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix at_hash verification #200
 * Getters for public parameters #204
 * Removed client ID query parameter when making a token request using Basic Auth
+* Added scope parameter to refresh token request
 
 ### Removed
 * Removed explicit content-length header - caused issues with proxy servers

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -743,6 +743,7 @@ class OpenIDConnectClient
             'refresh_token' => $refresh_token,
             'client_id' => $this->clientID,
             'client_secret' => $this->clientSecret,
+	    'scope'         => implode(' ', $this->scopes),
         );
 
         // Convert token params to string format

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -743,7 +743,7 @@ class OpenIDConnectClient
             'refresh_token' => $refresh_token,
             'client_id' => $this->clientID,
             'client_secret' => $this->clientSecret,
-	    'scope'         => implode(' ', $this->scopes),
+            'scope'         => implode(' ', $this->scopes),
         );
 
         // Convert token params to string format


### PR DESCRIPTION
Some providers require an optional scope when requesting a refresh of a token. If not provided they will return an invalid_request error. 
Scope for the refresh token should be the same scope as the access token, so using the same method should be sufficient.

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
