### PR TITLE
Added cURL error code to existing error message

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1141,7 +1141,7 @@ class OpenIDConnectClient
         $this->responseCode = $info['http_code'];
 
         if ($output === false) {
-            throw new OpenIDConnectClientException('Curl error: ' . curl_error($ch));
+            throw new OpenIDConnectClientException('Curl error: (' . curl_errno($ch) . ') ' . curl_error($ch));
         }
 
         // Close the cURL resource, and free system resources


### PR DESCRIPTION
This simple, non-intrusive change should make the cURL error message easier to debug. I ran into some issues with SELinux (or Fedora, not sure) earlier today and weirdly, `curl_error()` would just return NULL, thus resulting in a pretty non-descriptive error message of `Curl error: ` 

I had to add `curl_errno()` into the source to debug the issue, and I think this would be something nice to add to the library itself  for easier debugging :)

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
