### PR TITLE
add get/setHttpUpgradeInsecureRequests(), fixes #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## master
+
+### Added
+* it is now possible to disable upgrading from HTTP to HTTPS for development purposes by calling `setHttpUpgradeInsecureRequests(false)`
+
 ## [0.9.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,10 +153,16 @@ $oidc->setVerifyHost(false);
 $oidc->setVerifyPeer(false);
 ```
 
+Also, your local system might not support HTTPS, so you might disable uprading to it:
+
+```php
+$oidc->httpUpgradeInsecureRequests(false);
+```
+
 ### Todo ###
 - Dynamic registration does not support registration auth tokens and endpoints
 
   [1]: http://openid.net/specs/openid-connect-basic-1_0-15.html#id_res
   
 ## Contributing ###
- - All pull requests, once merged, should be added to the changelog.md file.
+ - All pull requests, once merged, should be added to the CHANGELOG.md file.

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -227,6 +227,11 @@ class OpenIDConnectClient
     protected $enc_type = PHP_QUERY_RFC1738;
 
     /**
+     * @var bool Enable or disable upgrading to HTTPS by paying attention to HTTP header HTTP_UPGRADE_INSECURE_REQUESTS
+     */
+    protected $httpUpgradeInsecureRequests = true;
+
+    /**
      * @var string holds code challenge method for PKCE mode
      * @see https://tools.ietf.org/html/rfc7636
      */
@@ -585,7 +590,7 @@ class OpenIDConnectClient
          * Support of 'ProxyReverse' configurations.
          */
 
-        if (isset($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS']) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] === '1')) {
+        if ($this->httpUpgradeInsecureRequests && isset($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS']) && ($_SERVER['HTTP_UPGRADE_INSECURE_REQUESTS'] === '1')) {
             $protocol = 'https';
         } else {
             $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
@@ -1292,6 +1297,16 @@ class OpenIDConnectClient
         $this->verifyHost = $verifyHost;
     }
 
+
+    /**
+     * Controls whether http header HTTP_UPGRADE_INSECURE_REQUESTS should be considered
+     * defaults to true
+     * @param bool $httpUpgradeInsecureRequests
+     */
+    public function setHttpUpgradeInsecureRequests($httpUpgradeInsecureRequests) {
+        $this->httpUpgradeInsecureRequests = $httpUpgradeInsecureRequests;
+    }
+
     /**
      * @return bool
      */
@@ -1306,6 +1321,14 @@ class OpenIDConnectClient
     public function getVerifyPeer()
     {
         return $this->verifyPeer;
+    }
+
+    /**
+     * @return bool 
+     */
+    public function getHttpUpgradeInsecureRequests()
+    {
+        return $this->httpUpgradeInsecureRequests;
     }
 
     /**


### PR DESCRIPTION
This PR enables to offer a more obvious way of disabling automatic upgrades from HTTP to HTTPS. This is useful for development purposes and fixes issue [174](https://github.com/jumbojett/OpenID-Connect-PHP/issues/174).

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
