### PR TITLE
Refactor session, add redis session support

### DIFF
--- a/src/Session/InMemory.php
+++ b/src/Session/InMemory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jumbojett\Session;
+
+/**
+ * Only for test purposes
+ */
+class InMemory implements Session
+{
+    /**
+     * @var State[]
+     */
+    private $storage = [];
+
+    public function get($id)
+    {
+        if(isset($this->storage[$id]))
+        {
+            return $this->storage[$id];
+        }
+        return null;
+    }
+
+    public function commit(State $state)
+    {
+        $this->storage[$state->getId()] = $state;
+    }
+
+    public function cleanup(State $state)
+    {
+        unset($this->storage[$state->getId()]);
+    }
+}

--- a/src/Session/PhpSession.php
+++ b/src/Session/PhpSession.php
@@ -1,0 +1,53 @@
+<?php
+namespace Jumbojett\Session;
+
+
+use function session_write_close;
+
+class PhpSession implements Session
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct($options = [])
+    {
+        $this->options = $options;
+    }
+
+    private function start() {
+        if (!isset($_SESSION)) {
+            session_start($this->options);
+        }
+    }
+
+    public function get($id) {
+        $this->start();
+
+        if(isset($_SESSION[$id]))  {
+            return new State($id, $_SESSION[$id]['nonce'], $_SESSION[$id]['code_verifier']);
+        }
+
+        return null;
+    }
+
+    public function commit(State $state) {
+        $this->start();
+
+        $_SESSION[$state->getId()] = [
+            'nonce' => $state->getNonce(),
+            'code_verifier' => $state->getCodeVerifier()
+        ];
+
+        session_write_close();
+    }
+
+    public function cleanup(State $state) {
+        $this->start();
+
+        unset($_SESSION[$state->getId()]);
+
+        session_write_close();
+    }
+}

--- a/src/Session/Redis.php
+++ b/src/Session/Redis.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jumbojett\Session;
+
+class Redis implements Session
+{
+    const PREFIX = 'oidc_state___';
+    const SEPARATOR = '___';
+    const TTL = 30;
+
+    /**
+     * @var \Redis
+     */
+    private $redis;
+
+    public function __construct(\Redis $redis){
+        $this->redis = $redis;
+    }
+
+
+    public function get($id)
+    {
+        $key = $this->buildKey($id);
+        $serialized = $this->redis->get($key);
+        if($serialized) {
+            return $this->deserialize($id, $serialized);
+        }
+        return null;
+    }
+
+    public function commit(State $state)
+    {
+        $key = $this->buildKey($state->getId());
+        $this->redis->set($key, $this->serialize($state), self::TTL);
+    }
+
+    public function cleanup(State $state)
+    {
+        $key = $this->buildKey($state->getId());
+        $this->redis->del($key);
+    }
+
+    private function serialize(State $state) {
+        return $state->getNonce() . self::SEPARATOR . $state->getCodeVerifier();
+    }
+
+    private function deserialize($id, $serialized) {
+        $parts = explode(self::SEPARATOR, $serialized, 2);
+        return new State($id, $parts[0], isset($parts[1]) ? $parts[1] : null);
+    }
+
+    private function buildKey($id) {
+        return self::PREFIX . $id;
+    }
+}

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -1,0 +1,23 @@
+<?php
+namespace Jumbojett\Session;
+
+interface Session
+{
+    /**
+     * @param string $id
+     * @return State
+     */
+    public function get($id);
+
+    /**
+     * @param State $state
+     * @return void
+     */
+    public function commit(State $state);
+
+    /**
+     * @param State $state
+     * @return void
+     */
+    public function cleanup(State $state);
+}

--- a/src/Session/State.php
+++ b/src/Session/State.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jumbojett\Session;
+
+class State
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $nonce;
+
+    /**
+     * @var null|string
+     */
+    private $codeVerifier;
+
+    /**
+     * State constructor.
+     * @param $id
+     * @param $nonce
+     * @param string|null $codeVerifier
+     */
+    public function __construct($id, $nonce, $codeVerifier = null) {
+        $this->id = $id;
+        $this->nonce = $nonce;
+        $this->codeVerifier = $codeVerifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNonce()
+    {
+        return $this->nonce;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCodeVerifier()
+    {
+        return $this->codeVerifier;
+    }
+
+    /**
+     * @param $codeVerifier
+     * @return State
+     */
+    public function setCodeVerifier($codeVerifier) {
+        return new self($this->id, $this->nonce, $codeVerifier);
+    }
+}

--- a/tests/AuthenticateWithSecretTest.php
+++ b/tests/AuthenticateWithSecretTest.php
@@ -1,0 +1,7 @@
+<?php
+
+
+class AuthenticateWithSecretTest
+{
+
+}

--- a/tests/AuthenticateWithSecretTest.php
+++ b/tests/AuthenticateWithSecretTest.php
@@ -1,7 +1,0 @@
-<?php
-
-
-class AuthenticateWithSecretTest
-{
-
-}

--- a/tests/InMemorySessionTest.php
+++ b/tests/InMemorySessionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Jumbojett\Session\InMemory;
+use Jumbojett\Session\State;
+
+class InMemorySessionTest extends PHPUnit_Framework_TestCase
+{
+    public function testCommit()
+    {
+        $session = new InMemory();
+        $state = new State('stateId', 'stateNonce', 'stateCodeVerifier');
+        $session->commit($state);
+
+        $this->assertEquals($state->getId(), $session->get('stateId')->getId());
+        $this->assertEquals($state->getNonce(), $session->get('stateId')->getNonce());
+    }
+
+    public function testCleanup()
+    {
+        $session = new InMemory();
+        $state = new State('stateId', 'stateNonce', 'stateCodeVerifier');
+        $session->commit($state);
+        $session->cleanup($state);
+
+        $this->assertEquals(null, $session->get('stateId'));
+    }
+
+    public function testNotExisting()
+    {
+        $session = new InMemory();
+        $this->assertEquals(null, $session->get('notExistingId'));
+    }
+}


### PR DESCRIPTION
This change refactors session and state concepts to be more inline with OIDC. Session interface allows for easier integration with existing code and other scenarios like adding OIDC to rest api where using cookie based sessions is just ugly.

There are no breaking changes, constructor defaults to php sessions. I will work well with dependency injection. 

Redis session implementation included as an real world working example :)

Btw. it will be nice to cover whole flow with tests, I tried to separate redirects and http client to make code more testable but it was just too much for one pull request.