### PR TITLE
Check if session key exists before accessing it

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1733,7 +1733,10 @@ class OpenIDConnectClient
     protected function getSessionKey($key) {
         $this->startSession();
 
-        return $_SESSION[$key];
+        if (array_key_exists($key, $_SESSION)) {
+            return $_SESSION[$key];
+        }
+        return false;
     }
 
     protected function setSessionKey($key, $value) {


### PR DESCRIPTION
I ran into this issue when trying to set up a basic OAuth flow using
this library and Keycloak. The issue was introduced by ce97230 which
checks for PKCE support, the way it does this is to call the function
getCodeVerifier() which in turn calls getSessionKey() which returns a
specified key from _SESSION. This will fail when setting up a client
without PKCE because the key will not exist.

With this commit a sanity check is introduced which first checks if the
key exists in _SESSION before returning it, otherwise just returning
false. This should not affect existing library functionality.

Signed-off-by: Erik Sjöström <erikdsjostrom@gmail.com>