### PR TITLE
Add form post data functionality to requestUserInfo method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.3]
+### Added
+* Support for form-encoded body parameter when using requestUserInfo function [rfc6750#2.2](https://tools.ietf.org/html/rfc6750#section-2.2).
+
 ## [0.9.2]
 
 ### Added

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1033,6 +1033,7 @@ class OpenIDConnectClient
     /**
      *
      * @param string|null $attribute optional
+     * @param boolean $usePostData optional
      *
      * Attribute        Type        Description
      * user_id          string      REQUIRED Identifier for the End-User at the Issuer.
@@ -1058,10 +1059,11 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function requestUserInfo($attribute = null) {
+    public function requestUserInfo($attribute = null, $usePostData = false) {
 
         $user_info_endpoint = $this->getProviderConfigValue('userinfo_endpoint');
         $schema = 'openid';
+        $post_data = null;
 
         $user_info_endpoint .= '?schema=' . $schema;
 
@@ -1070,7 +1072,12 @@ class OpenIDConnectClient
         $headers = ["Authorization: Bearer {$this->accessToken}",
             'Accept: application/json'];
 
-        $user_json = json_decode($this->fetchURL($user_info_endpoint,null,$headers));
+        if ($usePostData) {
+            $headers = null;
+            $post_data = http_build_query(['access_token' => $this->accessToken,],null,'&');
+        }
+
+        $user_json = json_decode($this->fetchURL($user_info_endpoint,$post_data,$headers));
         if ($this->getResponseCode() <> 200) {
             throw new OpenIDConnectClientException('The communication to retrieve user data has failed with status code '.$this->getResponseCode());
         }


### PR DESCRIPTION
Based on https://tools.ietf.org/html/rfc6750#section-2.2 you should be able to send an access_token via form data instead of via an Authorization header.

This pull request adds an optional parameter to the method requestUserInfo to use form data to send the access_token.

**List of common tasks a pull request require complete**
- [X] Changelog entry is added or the pull request don't alter library's functionality
