### PR TITLE
Support for phpseclib v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+* Support for [phpseclib/phpseclib](https://phpseclib.com/) version **3**.
+
 ## [0.9.5]
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "phpseclib/phpseclib" : "~2.0",
+        "phpseclib/phpseclib" : "~2.0 || ^3.0",
         "ext-json": "*",
         "ext-curl": "*",
         "paragonie/random_compat": ">=2"
@@ -20,10 +20,5 @@
     },
     "autoload" : {
          "classmap": [ "src/"]
-    },
-  "config" : {
-    "platform": {
-      "php": "5.4"
     }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     },
     "autoload" : {
          "classmap": [ "src/"]
+    },
+    "config" : {
+        "platform": {
+            "php": "5.4"
+        }
     }
 }


### PR DESCRIPTION
Resolves #253: changes added support for phpseclib version 3 with backward compatibility with version 2 (or [phpseclib2_compat](https://github.com/phpseclib/phpseclib2_compat)).

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
