### PR TITLE
Add a way to call your own redirect function on redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [next]
+* Add support for providing your own redirect function
+
 ## [0.9.2]
 
 ### Added

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -219,6 +219,12 @@ class OpenIDConnectClient
      * @var bool Allow OAuth 2 implicit flow; see http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth
      */
     private $allowImplicitFlow = false;
+
+    /**
+     * @var callable redirect function
+     */
+    private $redirectFn;
+
     /**
      * @var string
      */
@@ -550,6 +556,16 @@ class OpenIDConnectClient
         $this->wellKnownConfigParameters=$params;
     }
 
+    /**
+     * Use this for custom redirection
+     * The given function should accept the redirect URL as the only argument,
+     * send the appropriate headers and call exit to terminate execution.
+     *
+     * @param callable $fn
+     */
+    public function setRedirectFn($fn) {
+        $this->redirectFn = $fn;
+    }
 
     /**
      * @param string $url Sets redirect URL for auth flow
@@ -1252,6 +1268,9 @@ class OpenIDConnectClient
      * @param string $url
      */
     public function redirect($url) {
+        if ($this->redirectFn) {
+            call_user_func($this->redirectFn, $url);
+        }
         header('Location: ' . $url);
         exit;
     }


### PR DESCRIPTION
If you have special requirements, or need to do some house-keeping before redirecting the user to the auth_endpoint or signout_endpoint, use this to designate that function.

The provided redirect function should either do only house keeping tasks, or also provide the required location header and call exit.