### PR TITLE
verifyJWTclaims: fixed an exception when $accessToken is null

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1004,7 +1004,7 @@ class OpenIDConnectClient
             && ($claims->nonce === $this->getNonce())
             && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
             && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
-            && ( !isset($claims->at_hash) || $claims->at_hash === $expected_at_hash )
+            && ( !isset($claims->at_hash) || !isset($accessToken) || $claims->at_hash === $expected_at_hash )
         );
     }
 


### PR DESCRIPTION
- [x] Changelog entry is added or the pull request don't alter library's functionality

This patches fixes a *undefined variable* bug appearing when `$accessToken` is null but `$claims` contains `at_hash`:


The only way `$expected_at_hash` can be defined is if `$claims->at_hash` and `$accessToken` are not empty:

https://github.com/jumbojett/OpenID-Connect-PHP/blob/4f95102af87f86c43e8191ec6e90d9f35ed1ce5f/src/OpenIDConnectClient.php#L992

However if `$accessToken` is empty and `$claims->at_hash` is not, the `$claims->at_hash === $expected_at_hash` test is executed, and raises the exception.
This is fixed by this patch.