### PR TITLE
Accept doubles (microseconds) in JWT timestamps when verifying claims.

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1027,8 +1027,8 @@ class OpenIDConnectClient
         return (($this->issuerValidator->__invoke($claims->iss))
             && (($claims->aud === $this->clientID) || in_array($this->clientID, $claims->aud, true))
             && (!isset($claims->nonce) || $claims->nonce === $this->getNonce())
-            && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
-            && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
+            && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer' || gettype($claims->exp) === 'double') && ($claims->exp >= time() - $this->leeway)))
+            && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer' || gettype($claims->exp) === 'double') && ($claims->nbf <= time() + $this->leeway)))
             && ( !isset($claims->at_hash) || !isset($accessToken) || $claims->at_hash === $expected_at_hash )
         );
     }


### PR DESCRIPTION
Hi there

When implementing your library we noticed that tokens fail verification.
After some debugging we noticed, that the iobucci/jwt library issues timestamps in milliseconds (double) which fails your claim verification which expects an integer.

There was a [discussion](https://github.com/lcobucci/jwt/issues/229) at the iobucci/jwt library regarding this topic ending in a wontfix.

[RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-2) says

   NumericDate
      A JSON numeric value representing the number of seconds from
      1970-01-01T00:00:00Z UTC until the specified UTC date/time,
      ignoring leap seconds.  This is equivalent to the IEEE Std 1003.1,
      2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in
      which each day is accounted for by exactly 86400 seconds, **other
      than** that **non-integer values** can be represented.  **See RFC 3339
      [RFC3339]** for details regarding date/times in general and UTC in
      particular.

In our opinion the definition is not clear as it not says explicit the seconds timestamp MUST be an integer.
It can be read as implicit definition of an integer if "other than that non-integer values" is meant regarding RFC 3339 which is mostly about Date/Time representation as string.

This PR alters your claim verification by allowing integer **and** double as type for the timestamps.

**List of common tasks a pull request require complete**
- [] Changelog entry is added or the pull request don't alter library's functionality
