### PR TITLE
fix: allow serializing OpenIDConnectClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Support for [phpseclib/phpseclib](https://phpseclib.com/) version **3**. #260
 * Support client_secret on token endpoint with PKCE. #293
 
+### Changed
+
+* Allow serializing `OpenIDConnectClient` using `serialize()`
+
 ## [0.9.5]
 
 ### Changed

--- a/tests/OpenIDConnectClientTest.php
+++ b/tests/OpenIDConnectClientTest.php
@@ -55,4 +55,11 @@ class OpenIDConnectClientTest extends TestCase
             }
         }
     }
+
+    public function testSerialize()
+    {
+        $client = new OpenIDConnectClient('https://example.com', 'foo', 'bar', 'baz');
+        $serialized = serialize($client);
+        $this->assertInstanceOf('Jumbojett\OpenIDConnectClient', unserialize($serialized));
+    }
 }


### PR DESCRIPTION
Currently, it's not possible to store a client instance in the session. This is useful when creating dynamic clients such as when implementing [Solid OIDC](https://solid.github.io/solid-oidc/): you need a different client per user.

This PR fixes the issue without introducing a BC break.

- [x] Changelog entry is added