### PR TITLE
feat: allow passing custom headers to requestTokens()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+
 * Support for [phpseclib/phpseclib](https://phpseclib.com/) version **3**. #260
 * Support client_secret on token endpoint with PKCE. #293
+* Added new parameter to `requestTokens()` to pass custom HTTP headers #297
 
 ### Changed
 
-* Allow serializing `OpenIDConnectClient` using `serialize()`
+* Allow serializing `OpenIDConnectClient` using `serialize()` #295
 
 ## [0.9.5]
 


### PR DESCRIPTION
To support OAuth 2 [DPoP](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-dpop), an extra header named `DPoP` must be passed to the server.

This new parameter allows doing this (by overriding the `requestTokens()` method), as well as passing any other custom header.

- [x] Changelog entry is added or the pull request don't alter library's functionality
