### PR TITLE
Add support for back-channel logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 * Harden self-signed JWK header usage. #323
+* Added support for back-channel logout. #302
 
 ## [0.9.8]
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -517,7 +517,7 @@ class OpenIDConnectClient
 
     /**
      * Verify each claim in the logout token according to the
-     * spec for back-channel authentication.
+     * spec for back-channel logout.
      *
      * @param object $claims
      * @return bool


### PR DESCRIPTION
Fixes #116

This adds functions that support back-channel logout.

With this, an implementor can evaluate `verifyLogoutToken()` and if true, proceed with the developer's application-specific technique for ending the subject's session in the RP. (How that is done is left up to the developer, per the OIDC spec. In my case it involves checking server-side for an existing session based on the `sid` received in the back-channel logout token, and destroying it if found. Working great for my needs)

I borrowed some of this code from an existing fork of this project, which I discovered by chance whilst browsing the 'downstream' forks. I guess it was never contributed back: https://github.com/dptsi/php-openid-connect-client/blob/master/src/OpenIDConnectClient.php#L1989-L2049

Please use this part of the spec to check the validation is correct: https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation

- [x]  Changelog entry is added