### PR TITLE
support refresh_token_expires_in during authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Added
+
+* Support for capturing `refresh_token_expires_in` during `authenticate()`
+
 ## [0.9.7]
 
 ### Added

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -360,6 +360,11 @@ class OpenIDConnectClient
                 if (isset($token_json->refresh_token)) {
                     $this->refreshToken = $token_json->refresh_token;
                 }
+		    
+		// Save the refresh token expiration (seconds), if we got one
+		if (isset($token_json->refresh_token_expires_in)) {
+                    $this->refreshTokenExpiresIn = $token_json->refresh_token_expires_in;
+                }
 
                 // Success!
                 return true;


### PR DESCRIPTION
`refresh_token_expires_in` is an attribute our Microsoft ADFS gives back during `authenticate` > `requestTokens`. Here's related doc from Microsoft: https://docs.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens?view=li-lms-2022-07

It would be helpful to capture this value for extra transparency. Later it could be used to detect if a refresh token is already expired before attempting to use it.