### PR TITLE
feat: add client_secret_jwt support

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -811,7 +811,7 @@ class OpenIDConnectClient
             $token_params['client_assertion_type'] = $client_assertion_type;
             $token_params['client_assertion'] = $client_assertion;
             unset($token_params['client_secret']);
-	    }
+	}
 
         $ccm = $this->getCodeChallengeMethod();
         $cv = $this->getCodeVerifier();


### PR DESCRIPTION
## Add `client_secret_jwt` as supported method for Client Authentication [OpenID Connect Client Authentication](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)

** Changes **
- [x] Added new token endpoint auth method supported 
- [x] Added a method for obtaining JWT Client Assertion
- [x] Added `PS512` encryption support in `verifyJWTsignature` method 