### PR TITLE
Added support for private_key_jwt authentication method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+* Added support for `private_key_jwt` Client Authentication method #322
 
 ## [0.9.8]
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -806,7 +806,7 @@ class OpenIDConnectClient
         // When there is a private key jwt generator and it is supported then use it as client authentication
         if ($this->privateKeyJwtGenerator !== null && in_array('private_key_jwt', $token_endpoint_auth_methods_supported, true)) {
             $token_params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
-            $token_params['client_assertion'] = $this->privateKeyJwtGenerator($token_endpoint);
+            $token_params['client_assertion'] = $this->privateKeyJwtGenerator->__invoke($token_endpoint);
         }
 
         $ccm = $this->getCodeChallengeMethod();


### PR DESCRIPTION
Added support for `private_key_jwt` Client Authentication method according to https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
