### PR TITLE
fix: harden self signed JWK header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## Fixed
+
+* Harden self-signed JWK header usage. #323
+
 ## [0.9.8]
 
 ## Fixed

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1066,6 +1066,7 @@ class OpenIDConnectClient
 
                 if (isset($header->jwk)) {
                     $jwk = $header->jwk;
+                    $this->verifyJWKHeader($jwk);
                 } else {
                     $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
                     if ($jwks === NULL) {
@@ -1941,5 +1942,13 @@ class OpenIDConnectClient
      */
     public function setCodeChallengeMethod($codeChallengeMethod) {
         $this->codeChallengeMethod = $codeChallengeMethod;
+    }
+
+    /**
+     * @throws OpenIDConnectClientException
+     */
+    protected function verifyJWKHeader($jwk)
+    {
+        throw new OpenIDConnectClientException('Self signed JWK header is not valid');
     }
 }


### PR DESCRIPTION
refs https://portswigger.net/kb/issues/00200902_jwt-self-signed-jwk-header-supported

JWK header shall not be used without verification.

## Usage:
In case self signed JWK header is desired to be used (very rare cases from my understanding) the class OpenIDConnectClient shall be sub classed and the method verifyJWKHeader implemented as needed

```php
use Jumbojett\OpenIDConnectClient;
use Jumbojett\OpenIDConnectClientException;

class MyOpenIDConnectClient extends OpenIDConnectClient
{
    protected function verifyJWKHeader($jwk)
    {
        # TODO: add your own logic to verify
        if ($not_valid) {
            throw new OpenIDConnectClientException('Self signed JWK header is not valid');
        }
    }
}
```


**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
