### PR TITLE
Fix PHPDoc return type for getTokenResponse function

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -145,7 +145,7 @@ class OpenIDConnectClient
     protected $idToken;
 
     /**
-     * @var string stores the token response
+     * @var object stores the token response
      */
     private $tokenResponse;
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1882,7 +1882,7 @@ class OpenIDConnectClient
     }
 
     /**
-     * @return string
+     * @return object
      */
     public function getTokenResponse() {
         return $this->tokenResponse;


### PR DESCRIPTION


- Nothing much, just fix the return type of the `getTokenResponse` function for PHPDoc