### PR TITLE
Add an extra check on $_REQUEST['state'] (issue #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+* Fixed issue on authentication for php8. #354
 * Support for signed and encrypted UserInfo response. #305
 * Support for signed and encrypted ID Token. #305
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -338,7 +338,7 @@ class OpenIDConnectClient
             }
 
             // Do an OpenID Connect session check
-	    if (isset($_REQUEST['state']) && ($_REQUEST['state'] !== $this->getState())) {
+	    if (!isset($_REQUEST['state']) || ($_REQUEST['state'] !== $this->getState())) {
                 throw new OpenIDConnectClientException('Unable to determine state');
             }
 
@@ -401,7 +401,7 @@ class OpenIDConnectClient
             }
 
             // Do an OpenID Connect session check
-	    if (isset($_REQUEST['state']) && ($_REQUEST['state'] !== $this->getState())) {            
+	    if (!isset($_REQUEST['state']) || ($_REQUEST['state'] !== $this->getState())) {            
                 throw new OpenIDConnectClientException('Unable to determine state');
             }
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -338,7 +338,7 @@ class OpenIDConnectClient
             }
 
             // Do an OpenID Connect session check
-            if ($_REQUEST['state'] !== $this->getState()) {
+	    if (isset($_REQUEST['state']) && ($_REQUEST['state'] !== $this->getState())) {
                 throw new OpenIDConnectClientException('Unable to determine state');
             }
 
@@ -401,7 +401,7 @@ class OpenIDConnectClient
             }
 
             // Do an OpenID Connect session check
-            if ($_REQUEST['state'] !== $this->getState()) {
+	    if (isset($_REQUEST['state']) && ($_REQUEST['state'] !== $this->getState())) {            
                 throw new OpenIDConnectClientException('Unable to determine state');
             }
 


### PR DESCRIPTION
This will prevent php warning for php 8 project while trying to authenticate client. 

**List of common tasks a pull request require complete**
- [ ] Fix php 8  warning on client authenticate

