### PR TITLE
Set the User-Agent regardless of GET or POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+* User-Agent is set for any HTTP method in fetchURL() (not just POST). #382
 * Update visibility of getWellKnownConfigValue to protected. #363
 * Fixed issue on authentication for php8. #354
 * Support for signed and encrypted UserInfo response. #305

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1367,7 +1367,6 @@ class OpenIDConnectClient
             // Allows to keep the POST method even after redirect
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
             curl_setopt($ch, CURLOPT_POSTFIELDS, $post_body);
-            curl_setopt($ch, CURLOPT_USERAGENT, $this->getUserAgent());
 
             // Default content type is form encoded
             $content_type = 'application/x-www-form-urlencoded';
@@ -1380,6 +1379,9 @@ class OpenIDConnectClient
             // Add POST-specific headers
             $headers[] = "Content-Type: $content_type";
         }
+
+        // Set the User-Agent
+        curl_setopt($ch, CURLOPT_USERAGENT, $this->getUserAgent());
 
         // If we set some headers include them
         if(count($headers) > 0) {


### PR DESCRIPTION
I am working with an OP that rejects the GET request to `/.well-known/openid-configuration` because the User-Agent is null.

Rather than only set the User-Agent only on POST requests, always send it (so it works for GET as well).

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
