### PR TITLE
chore(deps): update phpseclib/phpseclib requirement from ~3.0 to ^3.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "phpseclib/phpseclib" : "~2.0 || ^3.0",
+        "phpseclib/phpseclib" : "^2.0.31 || ^3.0.7",
         "ext-json": "*",
         "ext-curl": "*",
         "paragonie/random_compat": ">=2"

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,10 @@
     "description": "Bare-bones OpenID Connect client",
     "license": "Apache-2.0",
     "require": {
-        "phpseclib/phpseclib" : "^2.0.31 || ^3.0.7",
         "php": ">=7.0",
         "ext-json": "*",
         "ext-curl": "*",
-        "phpseclib/phpseclib": "~3.0"
+        "phpseclib/phpseclib": "^3.0.7"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
https://github.com/php-amqplib/php-amqplib/issues/914

phpseclib before 2.0.31 and 3.x before 3.0.7 mishandles RSA PKCS#1 v1.5 signature verification.

Reference: CVE-2021-30130 | CVSS Score: 7.5 | Category: CWE-347 | phpseclib before 2.0.31 and 3.x before 3.0.7 mishandles RSA PKCS#1 v1.5 signature verification.
