### PR TITLE
Updated minimum version of 2.x and 3.x according to CWE-347 | phpsecl…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "phpseclib/phpseclib" : "~2.0 || ^3.0",
+        "phpseclib/phpseclib" : "^2.0.31 || ^3.0.7",
         "ext-json": "*",
         "ext-curl": "*",
         "paragonie/random_compat": ">=2"


### PR DESCRIPTION
…ib before 2.0.31 and 3.x before 3.0.7 mishandles RSA PKCS#1 v1.5 signature verification

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
