### PR TITLE
Break nonce handling out of OpenIDConnectClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed LogoutToken verification for single value aud claims #334
 * Added function to set useragent #370
 * Update well known config value function response types #376
+* Added support for custom nonce handling #401
 
 ### Added
 - Support for signed and encrypted UserInfo response. #305


### PR DESCRIPTION
So we've got a custom session handler, and right now we've got a fork of this we use that overrides the session handling.

This PR would make that unessessary for us. It breaks nonce handling out into a `SessionNonceHandler` object. 

This would allows users like us to implement a custom `NonceHandler` that writes to nonces somewhere other than $_SESSION, wherever the user desires.

As this can be optionally passed to the constructor, it does not break the current interface as it is an optional final argument.

Let me know what you think, I am more than happy to change anything about this you wish.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
