### PR TITLE
Check if subject is equal to subject of id token when verifying JWT claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated readme PHP requirement to PHP 7.0+ #407
 - Added dependabot for GitHub Actions #407
 - Cast `$_SERVER['SERVER_PORT']` to integer to prevent adding 80 or 443 port to redirect URL. #403
+- Check subject when verifying JWT #406
 
 ## [1.0.0] - 2023-12-13
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1206,6 +1206,7 @@ class OpenIDConnectClient
         }
         return (($this->validateIssuer($claims->iss))
             && (($claims->aud === $this->clientID) || in_array($this->clientID, $claims->aud, true))
+            && ($claims->sub === $this->getIdTokenPayload()->sub)
             && (!isset($claims->nonce) || $claims->nonce === $this->getNonce())
             && ( !isset($claims->exp) || ((is_int($claims->exp)) && ($claims->exp >= time() - $this->leeway)))
             && ( !isset($claims->nbf) || ((is_int($claims->nbf)) && ($claims->nbf <= time() + $this->leeway)))

--- a/tests/OpenIDConnectClientTest.php
+++ b/tests/OpenIDConnectClientTest.php
@@ -26,6 +26,7 @@ class OpenIDConnectClientTest extends TestCase
         $fakeClaims = new StdClass();
         $fakeClaims->iss = 'fake-issuer';
         $fakeClaims->aud = 'fake-client-id';
+        $fakeClaims->sub = 'fake-sub';
         $fakeClaims->nonce = null;
 
         $_REQUEST['id_token'] = 'abc.123.xyz';


### PR DESCRIPTION
According to the OIDC spec [5.3.2. Successful Userinfo Response](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) we need to be sure of the following:

> The sub (subject) Claim MUST always be returned in the UserInfo Response.

And: 

> NOTE: Due to the possibility of token substitution attacks (see [Section 16.11](https://openid.net/specs/openid-connect-core-1_0.html#TokenSubstitution)), the UserInfo Response is not guaranteed to be about the End-User identified by the sub (subject) element of the ID Token. The sub Claim in the UserInfo Response MUST be verified to exactly match the sub Claim in the ID Token; if they do not match, the UserInfo Response values MUST NOT be used.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
