### PR TITLE
Changed parameter #2 of http_build_query to empty string on requestTokenExchange to support PHP8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Changed parameter #2 of http_build_query to empty string on requestTokenExchange to support PHP8.x
+
 ## [1.0.0] - 2023-12-13
 
 ### Added

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -972,7 +972,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->encType);
+        $post_params = http_build_query($post_data, '', '&', $this->encType);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers), false);
     }


### PR DESCRIPTION
**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
