### PR TITLE
fix(urlencode): resolve issue with passing null to urlencode() in PHP 8+

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -880,7 +880,7 @@ class OpenIDConnectClient
         $authorizationHeader = null;
         # Consider Basic authentication if provider config is set this way
         if ($this->supportsAuthMethod('client_secret_basic', $token_endpoint_auth_methods_supported)) {
-            $authorizationHeader = 'Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret));
+            $authorizationHeader = 'Authorization: Basic ' . base64_encode($this->clientID . ':' . $this->clientSecret);
             unset($token_params['client_secret'], $token_params['client_id']);
         }
 


### PR DESCRIPTION
 - Remove urlencode() to prevent deprecation warnings regarding null parameter