### PR TITLE
Split up interface to allow per action use

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -293,8 +293,8 @@ class OpenIDConnectClient
     }
 	
 	/**
-	 * use this method to magically handle all incoming OIDC requests at one endpoint
-	 * if you need more control, use the handleError(), handleCode(), handleClaims(), requestAuthorisation() and redirect() methods
+	 * use this method to magically handle all incoming OIDC requests
+	 * if you need more control per request, use the methods handleError(), handleCode(), handleClaims(), requestAuthorisation() and redirect()
 	 * @return bool
 	 * @throws OpenIDConnectClientException
 	 */


### PR DESCRIPTION
**Allowing the caller to call the magical request handler `authenticate` or to have more control over the process and call the individual actions themself**
- [ ] Added public methods per action (`requestAuthorization`, `handleCode`, `handleClaims`) 
- [ ] `authenticate()` makes use of newly created atomic actions
