### PR TITLE
fix(php8): update http_build_query() usage for PHP 8+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-09-20
+
+### Fixed
+
+- Fixed compatibility with PHP 8 and above by updating `http_build_query()` usage. The second argument was changed from `null` to an empty string `''` to ensure proper query string generation in PHP 8+ environments. #413
+
 ## [1.0.1] - 2024-09-13
 
 ### Fixed

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -967,7 +967,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->encType);
+        $post_params = http_build_query($post_data, '', '&', $this->encType);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers), false);
     }


### PR DESCRIPTION
 - Changed second argument from  to an empty string  to ensure proper query string generation
 - This pr closes #413 