### PR TITLE
fix(php8): resolve deprecation warning for urlencode() in PHP 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-09-23
+
+### Fixed
+
+- Updated `$clientID` and `$clientSecret` in the authentication flow to default to an empty string (`''`) if they are `null`. This resolves potential issues in PHP 8+ where `urlencode()` would throw deprecation warnings when passed `null`.
+
 ## [1.0.1] - 2024-09-13
 
 ### Fixed

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -880,6 +880,8 @@ class OpenIDConnectClient
         $authorizationHeader = null;
         # Consider Basic authentication if provider config is set this way
         if ($this->supportsAuthMethod('client_secret_basic', $token_endpoint_auth_methods_supported)) {
+            $this->clientID = $this->clientID ?? '';
+            $this->clientSecret = $this->clientSecret ?? '';
             $authorizationHeader = 'Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret));
             unset($token_params['client_secret'], $token_params['client_id']);
         }


### PR DESCRIPTION
 - Updated `client_id` and `client_secret` in `OpenIDConnectClient` constructor to default to an empty string ('') instead of `null`

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
