### PR TITLE
fix: protected responseContentType to allow overloading of fetchUrl function

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -149,7 +149,7 @@ class OpenIDConnectClient
     /**
      * @var string|null Content type from the server
      */
-    private $responseContentType;
+    protected $responseContentType;
 
     /**
      * @var array holds response types


### PR DESCRIPTION
Also set `responseContentType` to protected to allow proper overloading of fetchUrl.

Related: https://github.com/jumbojett/OpenID-Connect-PHP/pull/433