### PR TITLE
Stop adding `?schema=openid` to userinfo endpoint URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Stop adding ?schema=openid to userinfo endpoint URL. #449
+
 ## [1.0.1] - 2024-09-13
 
 ### Fixed

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1261,9 +1261,6 @@ class OpenIDConnectClient
     public function requestUserInfo(string $attribute = null) {
 
         $user_info_endpoint = $this->getProviderConfigValue('userinfo_endpoint');
-        $schema = 'openid';
-
-        $user_info_endpoint .= '?schema=' . $schema;
 
         //The accessToken has to be sent in the Authorization header.
         // Accept json to indicate response type


### PR DESCRIPTION
Stops appending a fixed (afaict, non-standard) query string to the userinfo endpoint.

Fixes #448 
Fixes #388 

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
