### PR TITLE
Avoided duplicates in scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Changed
+- Removed duplicates from scopes generated strings.
+
+## [unreleased]
+
+### Changed
 - Stop adding ?schema=openid to userinfo endpoint URL. #449
 
 ## [1.0.1] - 2024-09-13

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -548,7 +548,7 @@ class OpenIDConnectClient
      * @param array $scope - example: openid, given_name, etc...
      */
     public function addScope(array $scope) {
-        $this->scopes = array_merge($this->scopes, $scope);
+        $this->scopes = array_unique(array_merge($this->scopes, $scope));
     }
 
     /**
@@ -760,7 +760,7 @@ class OpenIDConnectClient
 
         // If the client has been registered with additional scopes
         if (count($this->scopes) > 0) {
-            $auth_params = array_merge($auth_params, ['scope' => implode(' ', array_merge($this->scopes, ['openid']))]);
+            $auth_params = array_merge($auth_params, ['scope' => implode(' ', array_unique(array_merge($this->scopes, ['openid'])))]);
         }
 
         // If the client has been registered with additional response types


### PR DESCRIPTION
Having duplicate in the scopes string can generate errors, to avoid this a array_unique has been added when working with scopes.

**List of common tasks a pull request require complete**
- [ x ] Changelog entry is added or the pull request don't alter library's functionality
