### PR TITLE
Check subject on unsigned / unencrypted response

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1303,6 +1303,11 @@ class OpenIDConnectClient
             $user_json = $claims;
         } else {
             $user_json = json_decode($response, false);
+
+            // Check subject
+            if(!isset($user_json->sub) || $user_json->sub !== $this->getIdTokenPayload()->sub){
+                throw new OpenIDConnectClientException('Invalid subject in user info response');
+            }
         }
 
         $userInfo = $user_json;


### PR DESCRIPTION
Currently the userinfo data is not checked for unsigned / unencrypted responses.
However the specs require a validation of the subject:

> The sub (subject) Claim MUST always be returned in the UserInfo Response.
> 
> NOTE: Due to the possibility of token substitution attacks (see Section 16.11), the UserInfo Response is not guaranteed to be about the End-User identified by the sub (subject) element of the ID Token. The sub Claim in the UserInfo Response MUST be verified to exactly match the sub Claim in the ID Token; if they do not match, the UserInfo Response values MUST NOT be used.

https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
