### PR TITLE
Fix: Verfify jti claim exists on backchannel logout token

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -249,6 +249,11 @@ class OpenIDConnectClient
     private $backChannelSubject;
 
     /**
+     * @var string jti (JWT ID) of back-channel logout it will be stored here
+     */
+    private $backChannelJti;
+
+    /**
      * @var array list of supported auth methods
      */
     private $token_endpoint_auth_methods_supported = ['client_secret_basic'];
@@ -514,6 +519,12 @@ class OpenIDConnectClient
         if (isset($claims->sub)) {
             $this->backChannelSubject = $claims->sub;
         }
+
+        // Verify that the Logout Token contains a jti Claim (Unique identifier for the token)
+        if(!isset($claims->jti)) {
+            return false;
+        }
+        $this->backChannelJti = $claims->jti;
 
         // Verify that the Logout Token contains an events Claim whose
         // value is a JSON object containing the member name
@@ -2067,6 +2078,11 @@ class OpenIDConnectClient
     public function getSubjectFromBackChannel(): string
     {
         return $this->backChannelSubject;
+    }
+
+    public function getJtiFromBackChannel(): string
+    {
+        return $this->backChannelJti;
     }
 
     public function supportsAuthMethod(string $auth_method, array $token_endpoint_auth_methods_supported): bool

--- a/tests/OpenIDConnectClientTest.php
+++ b/tests/OpenIDConnectClientTest.php
@@ -224,6 +224,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => 'fake-client-id',
                     'sid' => 'fake-client-sid',
                     'sub' => 'fake-client-sub',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -237,6 +238,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'sub' => 'fake-client-sub',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -248,6 +250,7 @@ class OpenIDConnectClientTest extends TestCase
                 (object)[
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -260,6 +263,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sub' => 'fake-client-sub',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -272,6 +276,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -284,6 +289,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
@@ -297,6 +303,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'nonce' => 'must-not-be-set'
                 ],
@@ -307,9 +314,22 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'iat' => time(),
                     'events' => (object) [],
                     'nonce' => 'must-not-be-set'
+                ],
+                false
+            ],
+            'invalid-no-jti' => [
+                (object)[
+                    'iss' => 'fake-issuer',
+                    'aud' => [ 'fake-client-id', 'some-other-aud' ],
+                    'sub' => 'fake-client-sub',
+                    'iat' => time(),
+                    'events' => (object) [
+                        'http://schemas.openid.net/event/backchannel-logout' => (object)[]
+                    ],
                 ],
                 false
             ],
@@ -318,6 +338,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ]
@@ -329,6 +350,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
                     'iat' => time() + 301,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]


### PR DESCRIPTION
https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken

> 2.4.  Logout Token
> The following Claims are used within the Logout Token:
> 
> [...]
> jti
> REQUIRED. Unique identifier for the token, as specified in Section 9 of [[OpenID.Core]](https://openid.net/specs/openid-connect-backchannel-1_0.html#OpenID.Core).
> [...]


**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
