### PR TITLE
Fix: Verfify exp claim on backchannel logout token 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Check existence of subject when verifying JWT #474
+- exp verification when verifying Logout Token claims #482
 
 ## [1.0.1] - 2024-09-13
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -536,12 +536,17 @@ class OpenIDConnectClient
         if (!in_array($this->clientID, $auds, true)) {
             return false;
         }
-        // Validate the iat. At this point we can return true if it is ok
-        if (isset($claims->iat) && ((is_int($claims->iat)) && ($claims->iat <= time() + $this->leeway))) {
-            return true;
+        // Validate iat exists, is an int, and is not in the future
+        if (!isset($claims->iat) || !is_int($claims->iat) || ($claims->iat >= time() + $this->leeway)) {
+            return false;
         }
 
-        return false;
+        // Validate exp exists, is an int, and is not too old
+        if (!isset($claims->exp) || !is_int($claims->exp) || ($claims->exp <= time() - $this->leeway)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/OpenIDConnectClientTest.php
+++ b/tests/OpenIDConnectClientTest.php
@@ -225,6 +225,7 @@ class OpenIDConnectClientTest extends TestCase
                     'sid' => 'fake-client-sid',
                     'sub' => 'fake-client-sub',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -238,6 +239,7 @@ class OpenIDConnectClientTest extends TestCase
                     'sid' => 'fake-client-sid',
                     'sub' => 'fake-client-sub',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -249,6 +251,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -261,6 +264,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sub' => 'fake-client-sub',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -273,6 +277,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -285,6 +290,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ],
@@ -298,6 +304,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'nonce' => 'must-not-be-set'
                 ],
                 false
@@ -308,6 +315,7 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'iat' => time(),
+                    'exp' => time() + 300,
                     'events' => (object) [],
                     'nonce' => 'must-not-be-set'
                 ],
@@ -318,6 +326,7 @@ class OpenIDConnectClientTest extends TestCase
                     'iss' => 'fake-issuer',
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
+                    'exp' => time() + 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ]
@@ -330,6 +339,34 @@ class OpenIDConnectClientTest extends TestCase
                     'aud' => [ 'fake-client-id', 'some-other-aud' ],
                     'sid' => 'fake-client-sid',
                     'iat' => time() + 301,
+                    'exp' => time() + 300,
+                    'events' => (object) [
+                        'http://schemas.openid.net/event/backchannel-logout' => (object)[]
+                    ]
+                ],
+                false
+            ],
+            'invalid-no-exp' => [
+                (object)[
+                    'iss' => 'fake-issuer',
+                    'aud' => [ 'fake-client-id', 'some-other-aud' ],
+                    'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
+                    'iat' => time(),
+                    'events' => (object) [
+                        'http://schemas.openid.net/event/backchannel-logout' => (object)[]
+                    ]
+                ],
+                false
+            ],
+            'invalid-bad-exp' => [
+                (object)[
+                    'iss' => 'fake-issuer',
+                    'aud' => [ 'fake-client-id', 'some-other-aud' ],
+                    'sid' => 'fake-client-sid',
+                    'jti' => 'fake-client-jti',
+                    'iat' => time(),
+                    'exp' => time() - 300,
                     'events' => (object) [
                         'http://schemas.openid.net/event/backchannel-logout' => (object)[]
                     ]


### PR DESCRIPTION
1. The Expiration time (exp) claim must exists on the Backchannel LogoutToken

https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken

> 2.4.  Logout Token
> The following Claims are used within the Logout Token:
> 
> [...]
> exp
> REQUIRED. Expiration time, as specified in Section 2 of [[OpenID.Core]](https://openid.net/specs/openid-connect-backchannel-1_0.html#OpenID.Core).
> [...]

2. The Expiration time (exp) claim must be from the future (with a small leeway)

https://openid.net/specs/openid-connect-core-1_0.html#IDToken
> Expiration time on or after which the ID Token MUST NOT be accepted by the RP when performing authentication with the OP. The processing of this parameter requires that the current date/time MUST be before the expiration date/time listed in the value. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew.

https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
> The current time MUST be before the time represented by the exp Claim.


**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
