### PR TITLE
PHP8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Check existence of subject when verifying JWT #474
 - exp verification when verifying Logout Token claims #482
+- http_build_query expects (non nullable) string as 2nd argument
+- curl_close() is ineffective since PHP 8.0.0, deprecated since 8.5.0
 
 ## [1.0.1] - 2024-09-13
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -972,7 +972,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->encType);
+        $post_params = http_build_query($post_data, '', '&', $this->encType);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers), false);
     }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1446,7 +1446,9 @@ class OpenIDConnectClient
         }
 
         // Close the cURL resource, and free system resources
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $output;
     }


### PR DESCRIPTION
- [ x ] Changelog entry is added or the pull request don't alter library's functionality

http_build_query expects a string, null no longer allowed.
curl_close() since PHP 8.0.0 ineffective, since 8.5.0 deprecated.