### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
         steps:
             - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Stop adding ?schema=openid to userinfo endpoint URL. #449
+- Drop support for PHP 7.1 #502
 
 ### Fixed
 - Check existence of subject when verifying JWT #474

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the OpenID Connect protocol to set up authentication.
 A special thanks goes to Justin Richer and Amanda Anganes for their help and support of the protocol.
 
 # Requirements #
- 1. PHP 7.1 or greater
+ 1. PHP 7.2 or greater
  2. CURL extension
  3. JSON extension
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Bare-bones OpenID Connect client",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-json": "*",
         "ext-curl": "*",
         "phpseclib/phpseclib": "^3.0.7"


### PR DESCRIPTION
This PR drops support for PHP 7.1 as proposed in https://github.com/jumbojett/OpenID-Connect-PHP/pull/501#issuecomment-4110471249.

Reasons:
* PHP 7.1 is EOL since December 2019 (= more than 6 years ago)
* `roave/security-advisories` blocks the installation of PHPUnit < 8.5.52 because of https://github.com/advisories/GHSA-vvj3-c3rp-c85p. However, PHPUnit 8.5 requires at least PHP 7.2. This breaks the PHP 7.1 CI job.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added
