### PR TITLE
Add option to ignore JWK from JWT header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Stop adding ?schema=openid to userinfo endpoint URL. #449
 - Drop support for PHP 7.1 #502
+- Add option to ignore JWK from JWT header #508
 
 ### Fixed
 - Check existence of subject when verifying JWT #474

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -193,6 +193,11 @@ class OpenIDConnectClient
     private $additionalJwks = [];
 
     /**
+     * @var bool ignore JWK from JWT header
+     */
+    private $ignoreJwkFromHeader = false;
+
+    /**
      * @var object holds verified jwt claims
      */
     protected $verifiedClaims = [];
@@ -1130,7 +1135,7 @@ class OpenIDConnectClient
             case 'RS512':
                 $hashType = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' || $header->alg === 'PS512' ? 'PSS' : '';
-                if (isset($header->jwk)) {
+                if (!$this->ignoreJwkFromHeader && isset($header->jwk)) {
                     $jwk = $header->jwk;
                     $this->verifyJWKHeader($jwk);
                 } else {
@@ -1520,6 +1525,10 @@ class OpenIDConnectClient
      */
     public function setHttpUpgradeInsecureRequests(bool $httpUpgradeInsecureRequests) {
         $this->httpUpgradeInsecureRequests = $httpUpgradeInsecureRequests;
+    }
+
+    public function setIgnoreJwkFromHeader(bool $ignoreJwkFromHeader) {
+        $this->ignoreJwkFromHeader = $ignoreJwkFromHeader;
     }
 
     public function getVerifyHost(): bool


### PR DESCRIPTION
The current implementation prefers the JWK from the JWT header over the keys retrieved from the jwks_uri, just to throw an exception. The option added by this PR allows to ignore the JWK in the JWT header and to use the one retrieved from the jwks_uri. For backward compatibility, the default behaviour is to not ignore the JWK from the JWT header.

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
